### PR TITLE
fix(ci): remove duplicate CI trigger on push + pull_request 🐛

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

- Scope `push` trigger to `main` only
- PRs trigger CI once via `pull_request`, merges to `main` trigger via `push`
- Eliminates duplicate CI runs when pushing to a branch with an open PR

## Test plan

- [x] Pushing to a branch with an open PR triggers exactly one CI run
- [x] Merging to `main` still triggers CI

Refs #15