### PR TITLE
feat(ui): add pipeline state machine and main activity UI ⛵

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -66,6 +66,11 @@ tasks.register<Exec>("downloadTtsModels") {
 dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
+    implementation(libs.google.material)
+    implementation(libs.androidx.constraintlayout)
+    implementation(libs.androidx.lifecycle.viewmodel)
+    implementation(libs.androidx.lifecycle.runtime)
+    implementation(libs.androidx.activity.ktx)
     implementation(libs.androidx.security.crypto)
     implementation(libs.matrix.sdk.android)
     implementation(libs.sherpa.onnx.android)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,7 +27,7 @@
     <application
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:theme="@style/Theme.AppCompat.DayNight.NoActionBar">
+        android:theme="@style/Theme.DeckChat">
 
         <activity
             android:name=".MainActivity"

--- a/app/src/main/java/dev/klazomenai/deckchat/MainActivity.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/MainActivity.kt
@@ -1,11 +1,64 @@
 package dev.klazomenai.deckchat
 
+import android.content.Intent
+import android.graphics.drawable.GradientDrawable
 import android.os.Bundle
+import android.view.View
+import android.widget.TextView
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import com.google.android.material.floatingactionbutton.FloatingActionButton
+import kotlinx.coroutines.launch
 
 class MainActivity : AppCompatActivity() {
+
+    private val viewModel: MainViewModel by viewModels()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
+        val stateLabel = findViewById<TextView>(R.id.state_label)
+        val stateIndicator = findViewById<View>(R.id.state_indicator)
+        val settingsFab = findViewById<FloatingActionButton>(R.id.settings_fab)
+
+        settingsFab.setOnClickListener {
+            startActivity(Intent(this, SettingsActivity::class.java))
+        }
+
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.state.collect { state ->
+                    updateStateUi(state, stateLabel, stateIndicator)
+                }
+            }
+        }
+    }
+
+    private fun updateStateUi(
+        state: PipelineState,
+        label: TextView,
+        indicator: View,
+    ) {
+        val (text, colorRes) = when (state) {
+            is PipelineState.Idle -> getString(R.string.state_idle) to R.color.state_idle
+            is PipelineState.Recording -> getString(R.string.state_recording) to R.color.state_recording
+            is PipelineState.Processing -> state.stage to R.color.state_processing
+            is PipelineState.Transcribed -> getString(R.string.state_transcribed) to R.color.state_transcribed
+            is PipelineState.Speaking -> getString(R.string.state_speaking, state.crewName) to R.color.state_speaking
+            is PipelineState.Error -> getString(R.string.state_error) to R.color.state_error
+        }
+
+        label.text = text
+        val color = ContextCompat.getColor(this, colorRes)
+        val background = indicator.background
+        if (background is GradientDrawable) {
+            background.mutate()
+            background.setColor(color)
+        }
     }
 }

--- a/app/src/main/java/dev/klazomenai/deckchat/MainViewModel.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/MainViewModel.kt
@@ -1,0 +1,59 @@
+package dev.klazomenai.deckchat
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * ViewModel for MainActivity. Holds the pipeline state and collects service events.
+ *
+ * Observes [RecordingService.serviceEvents] to translate service-level events into
+ * UI-facing [PipelineState] transitions.
+ */
+class MainViewModel : ViewModel() {
+
+    private val _state = MutableStateFlow<PipelineState>(PipelineState.Idle)
+    val state: StateFlow<PipelineState> = _state.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            RecordingService.serviceEvents.collect { event ->
+                when (event) {
+                    is ServiceEvent.RecordingStarted -> _state.value = PipelineState.Recording
+                    is ServiceEvent.RecordingStopped -> _state.value = PipelineState.Processing("Transcribing")
+                    is ServiceEvent.Error -> _state.value = PipelineState.Error(event.error)
+                }
+            }
+        }
+    }
+
+    /**
+     * Toggle recording on/off. Called from UI (FAB, headset button).
+     * Returns the intent action to dispatch, or null if no action needed.
+     */
+    fun toggleRecording(): String? {
+        return when (_state.value) {
+            is PipelineState.Idle, is PipelineState.Error -> {
+                _state.value = PipelineState.Recording
+                RecordingService.ACTION_START
+            }
+            is PipelineState.Recording -> {
+                RecordingService.ACTION_STOP
+            }
+            else -> null // Ignore during processing/speaking
+        }
+    }
+
+    /** Reset to idle — used after error display or TTS completion. */
+    fun resetToIdle() {
+        _state.value = PipelineState.Idle
+    }
+
+    /** Set state directly — used by the activity for pipeline stages not driven by service events. */
+    fun setState(newState: PipelineState) {
+        _state.value = newState
+    }
+}

--- a/app/src/main/java/dev/klazomenai/deckchat/PipelineState.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/PipelineState.kt
@@ -1,0 +1,31 @@
+package dev.klazomenai.deckchat
+
+/**
+ * Represents the current state of the voice pipeline.
+ *
+ * The state machine flows: Idle → Recording → Processing → Transcribed → Speaking → Idle.
+ * Any state can transition to Error; returning to Idle is handled explicitly by the caller.
+ */
+sealed class PipelineState {
+    data object Idle : PipelineState()
+    data object Recording : PipelineState()
+    data class Processing(val stage: String) : PipelineState()
+    data class Transcribed(val text: String) : PipelineState()
+    data class Speaking(val crewName: String) : PipelineState()
+    data class Error(val error: PipelineError) : PipelineState()
+}
+
+/**
+ * Categorised pipeline errors with enough context to show actionable UI feedback.
+ */
+sealed class PipelineError {
+    data object PermissionDenied : PipelineError()
+    data object PermissionPermanentlyDenied : PipelineError()
+    data object MicBusy : PipelineError()
+    data object AudioInitFailed : PipelineError()
+    data object ModelMissing : PipelineError()
+    data object BluetoothLost : PipelineError()
+    data class SttFailed(val message: String) : PipelineError()
+    data class TtsFailed(val message: String) : PipelineError()
+    data class MatrixFailed(val message: String) : PipelineError()
+}

--- a/app/src/main/java/dev/klazomenai/deckchat/RecordingService.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/RecordingService.kt
@@ -15,6 +15,10 @@ import android.media.MediaRecorder
 import android.os.Build
 import android.os.IBinder
 import androidx.core.content.ContextCompat
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import java.io.File
 import java.io.FileOutputStream
 
@@ -61,6 +65,7 @@ class RecordingService : Service() {
             // triggers SecurityException on API 34+ without RECORD_AUDIO regardless of
             // the type passed in code. Callers must check permission before using
             // startForegroundService; when started via plain startService, stopSelf is safe.
+            emitEvent(ServiceEvent.Error(PipelineError.PermissionDenied))
             stopSelf()
             return
         }
@@ -75,6 +80,7 @@ class RecordingService : Service() {
             }
         } catch (_: SecurityException) {
             // Race-condition guard: permission revoked between check and startForeground.
+            emitEvent(ServiceEvent.Error(PipelineError.PermissionDenied))
             stopSelf()
             return
         }
@@ -85,6 +91,8 @@ class RecordingService : Service() {
             AudioFormat.ENCODING_PCM_16BIT,
         )
         if (bufferSize <= 0) {
+            emitEvent(ServiceEvent.Error(PipelineError.AudioInitFailed))
+            stopForeground(STOP_FOREGROUND_REMOVE)
             stopSelf()
             return
         }
@@ -103,6 +111,8 @@ class RecordingService : Service() {
         if (audioRecord?.state != AudioRecord.STATE_INITIALIZED) {
             audioRecord?.release()
             audioRecord = null
+            emitEvent(ServiceEvent.Error(PipelineError.AudioInitFailed))
+            stopForeground(STOP_FOREGROUND_REMOVE)
             stopSelf()
             return
         }
@@ -117,6 +127,7 @@ class RecordingService : Service() {
             audioRecord?.release()
             audioRecord = null
             stopForeground(STOP_FOREGROUND_REMOVE)
+            emitEvent(ServiceEvent.Error(PipelineError.MicBusy))
             stopSelf()
             return
         }
@@ -128,10 +139,23 @@ class RecordingService : Service() {
                 if (read > 0) {
                     audioBuffer.add(buffer.copyOf(read))
                 } else if (read < 0) {
-                    break // AudioRecord error — exit to avoid busy-spin
+                    // AudioRecord error — stop recording and emit error
+                    isRecording = false
+                    try {
+                        audioRecord?.stop()
+                    } catch (_: IllegalStateException) {
+                        // Already stopped
+                    }
+                    audioRecord?.release()
+                    audioRecord = null
+                    emitEvent(ServiceEvent.Error(PipelineError.AudioInitFailed))
+                    stopForeground(STOP_FOREGROUND_REMOVE)
+                    stopSelf()
+                    return@Thread
                 }
             }
         }.also { it.start() }
+        emitEvent(ServiceEvent.RecordingStarted)
     }
 
     private fun stopRecording() {
@@ -154,6 +178,7 @@ class RecordingService : Service() {
         audioRecord = null
 
         val outputFile = writeBufferToFile()
+        emitEvent(ServiceEvent.RecordingStopped)
         listener?.onRecordingComplete(outputFile)
 
         stopForeground(STOP_FOREGROUND_REMOVE)
@@ -233,6 +258,18 @@ class RecordingService : Service() {
 
         fun setOnRecordingCompleteListener(l: OnRecordingCompleteListener?) {
             listener = l
+        }
+
+        private val _serviceEvents = MutableSharedFlow<ServiceEvent>(
+            extraBufferCapacity = 1,
+            onBufferOverflow = BufferOverflow.DROP_OLDEST,
+        )
+
+        /** Observable service events. Collected by [MainViewModel] to drive UI state. */
+        val serviceEvents: SharedFlow<ServiceEvent> = _serviceEvents.asSharedFlow()
+
+        internal fun emitEvent(event: ServiceEvent) {
+            _serviceEvents.tryEmit(event)
         }
     }
 }

--- a/app/src/main/java/dev/klazomenai/deckchat/ServiceEvent.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/ServiceEvent.kt
@@ -1,0 +1,18 @@
+package dev.klazomenai.deckchat
+
+/**
+ * Events emitted by [RecordingService] via its companion [RecordingService.serviceEvents] SharedFlow.
+ *
+ * The ViewModel collects these to drive [PipelineState] transitions without
+ * requiring a bound service connection.
+ */
+sealed class ServiceEvent {
+    /** Recording has started successfully. */
+    data object RecordingStarted : ServiceEvent()
+
+    /** Recording stopped normally — PCM file is ready. */
+    data object RecordingStopped : ServiceEvent()
+
+    /** An error occurred in the service. */
+    data class Error(val error: PipelineError) : ServiceEvent()
+}

--- a/app/src/main/res/drawable/state_indicator_circle.xml
+++ b/app/src/main/res/drawable/state_indicator_circle.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="@color/state_idle" />
+    <size android:width="16dp" android:height="16dp" />
+</shape>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,8 +1,48 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
+<androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
-</LinearLayout>
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:gravity="center"
+        android:padding="24dp">
+
+        <!-- State indicator dot -->
+        <View
+            android:id="@+id/state_indicator"
+            android:layout_width="16dp"
+            android:layout_height="16dp"
+            android:background="@drawable/state_indicator_circle"
+            android:layout_marginBottom="12dp"
+            android:importantForAccessibility="no" />
+
+        <!-- State label — live region announces changes for TalkBack -->
+        <TextView
+            android:id="@+id/state_label"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:accessibilityLiveRegion="polite"
+            android:text="@string/state_idle"
+            android:textSize="18sp"
+            android:textStyle="bold" />
+
+    </LinearLayout>
+
+    <!-- Settings gear (top-right) -->
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/settings_fab"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="top|end"
+        android:layout_margin="16dp"
+        android:contentDescription="@string/cd_settings"
+        android:src="@android:drawable/ic_menu_preferences"
+        app:fabSize="mini"
+        app:backgroundTint="@color/navy" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Primary palette (nautical theme) -->
+    <color name="navy">#1B3A5C</color>
+    <color name="navy_dark">#0F2440</color>
+    <color name="teal">#00838F</color>
+    <color name="teal_dark">#005662</color>
+    <color name="white">#FFFFFF</color>
+
+    <!-- State indicator colors -->
+    <color name="state_idle">#9E9E9E</color>
+    <color name="state_recording">#F44336</color>
+    <color name="state_processing">#FF9800</color>
+    <color name="state_transcribed">#2196F3</color>
+    <color name="state_speaking">#4CAF50</color>
+    <color name="state_error">#D32F2F</color>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,4 +9,15 @@
     <string name="session_active">Logged in as %1$s</string>
     <string name="session_none">No active session</string>
     <string name="clear_session_button">Clear Session</string>
+
+    <!-- Pipeline state labels -->
+    <string name="state_idle">Idle</string>
+    <string name="state_recording">Recording</string>
+    <string name="state_processing">Processing</string>
+    <string name="state_transcribed">Transcribed</string>
+    <string name="state_speaking">%1$s is speaking</string>
+    <string name="state_error">Error</string>
+
+    <!-- Content descriptions -->
+    <string name="cd_settings">Settings</string>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.DeckChat" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="colorPrimary">@color/navy</item>
+        <item name="colorPrimaryVariant">@color/navy_dark</item>
+        <item name="colorOnPrimary">@color/white</item>
+        <item name="colorSecondary">@color/teal</item>
+        <item name="colorSecondaryVariant">@color/teal_dark</item>
+        <item name="colorOnSecondary">@color/white</item>
+    </style>
+</resources>

--- a/app/src/test/java/dev/klazomenai/deckchat/MainViewModelTest.kt
+++ b/app/src/test/java/dev/klazomenai/deckchat/MainViewModelTest.kt
@@ -1,0 +1,133 @@
+package dev.klazomenai.deckchat
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `initial state is idle`() {
+        val viewModel = MainViewModel()
+        assertEquals(PipelineState.Idle, viewModel.state.value)
+    }
+
+    @Test
+    fun `toggleRecording from idle returns ACTION_START`() {
+        val viewModel = MainViewModel()
+        val action = viewModel.toggleRecording()
+        assertEquals(RecordingService.ACTION_START, action)
+    }
+
+    @Test
+    fun `toggleRecording from idle transitions to recording`() {
+        val viewModel = MainViewModel()
+        viewModel.toggleRecording()
+        assertEquals(PipelineState.Recording, viewModel.state.value)
+    }
+
+    @Test
+    fun `toggleRecording from recording returns ACTION_STOP`() {
+        val viewModel = MainViewModel()
+        viewModel.toggleRecording() // → Recording
+        val action = viewModel.toggleRecording()
+        assertEquals(RecordingService.ACTION_STOP, action)
+    }
+
+    @Test
+    fun `toggleRecording from processing returns null`() {
+        val viewModel = MainViewModel()
+        viewModel.setState(PipelineState.Processing("Transcribing"))
+        val action = viewModel.toggleRecording()
+        assertNull(action)
+    }
+
+    @Test
+    fun `toggleRecording from speaking returns null`() {
+        val viewModel = MainViewModel()
+        viewModel.setState(PipelineState.Speaking("Maren"))
+        val action = viewModel.toggleRecording()
+        assertNull(action)
+    }
+
+    @Test
+    fun `toggleRecording from error returns ACTION_START`() {
+        val viewModel = MainViewModel()
+        viewModel.setState(PipelineState.Error(PipelineError.MicBusy))
+        val action = viewModel.toggleRecording()
+        assertEquals(RecordingService.ACTION_START, action)
+    }
+
+    @Test
+    fun `resetToIdle sets state to idle`() {
+        val viewModel = MainViewModel()
+        viewModel.setState(PipelineState.Error(PipelineError.MicBusy))
+        viewModel.resetToIdle()
+        assertEquals(PipelineState.Idle, viewModel.state.value)
+    }
+
+    @Test
+    fun `setState updates state directly`() {
+        val viewModel = MainViewModel()
+        viewModel.setState(PipelineState.Transcribed("hello"))
+        assertTrue(viewModel.state.value is PipelineState.Transcribed)
+        assertEquals("hello", (viewModel.state.value as PipelineState.Transcribed).text)
+    }
+
+    @Test
+    fun `service event RecordingStarted transitions to recording`() = runTest {
+        val viewModel = MainViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        RecordingService.emitEvent(ServiceEvent.RecordingStarted)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(PipelineState.Recording, viewModel.state.value)
+    }
+
+    @Test
+    fun `service event RecordingStopped transitions to processing`() = runTest {
+        val viewModel = MainViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        RecordingService.emitEvent(ServiceEvent.RecordingStopped)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue(viewModel.state.value is PipelineState.Processing)
+    }
+
+    @Test
+    fun `service event Error transitions to error state`() = runTest {
+        val viewModel = MainViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        RecordingService.emitEvent(ServiceEvent.Error(PipelineError.PermissionDenied))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertTrue(state is PipelineState.Error)
+        assertEquals(PipelineError.PermissionDenied, (state as PipelineState.Error).error)
+    }
+}

--- a/app/src/test/java/dev/klazomenai/deckchat/PipelineStateTest.kt
+++ b/app/src/test/java/dev/klazomenai/deckchat/PipelineStateTest.kt
@@ -1,0 +1,114 @@
+package dev.klazomenai.deckchat
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PipelineStateTest {
+
+    @Test
+    fun `idle is singleton`() {
+        assertTrue(PipelineState.Idle === PipelineState.Idle)
+    }
+
+    @Test
+    fun `recording is singleton`() {
+        assertTrue(PipelineState.Recording === PipelineState.Recording)
+    }
+
+    @Test
+    fun `processing carries stage name`() {
+        val state = PipelineState.Processing("Transcribing")
+        assertEquals("Transcribing", state.stage)
+    }
+
+    @Test
+    fun `transcribed carries text`() {
+        val state = PipelineState.Transcribed("hello world")
+        assertEquals("hello world", state.text)
+    }
+
+    @Test
+    fun `speaking carries crew name`() {
+        val state = PipelineState.Speaking("Maren")
+        assertEquals("Maren", state.crewName)
+    }
+
+    @Test
+    fun `error wraps pipeline error`() {
+        val error = PipelineError.MicBusy
+        val state = PipelineState.Error(error)
+        assertEquals(PipelineError.MicBusy, state.error)
+    }
+
+    @Test
+    fun `all error types are distinct`() {
+        val errors: List<PipelineError> = listOf(
+            PipelineError.PermissionDenied,
+            PipelineError.PermissionPermanentlyDenied,
+            PipelineError.MicBusy,
+            PipelineError.AudioInitFailed,
+            PipelineError.ModelMissing,
+            PipelineError.BluetoothLost,
+            PipelineError.SttFailed("stt error"),
+            PipelineError.TtsFailed("tts error"),
+            PipelineError.MatrixFailed("matrix error"),
+        )
+        // All unique
+        assertEquals(errors.size, errors.toSet().size)
+    }
+
+    @Test
+    fun `stt failed carries message`() {
+        val error = PipelineError.SttFailed("model load failed")
+        assertEquals("model load failed", error.message)
+    }
+
+    @Test
+    fun `tts failed carries message`() {
+        val error = PipelineError.TtsFailed("voice not found")
+        assertEquals("voice not found", error.message)
+    }
+
+    @Test
+    fun `matrix failed carries message`() {
+        val error = PipelineError.MatrixFailed("connection refused")
+        assertEquals("connection refused", error.message)
+    }
+
+    @Test
+    fun `processing equality based on stage`() {
+        assertEquals(
+            PipelineState.Processing("Transcribing"),
+            PipelineState.Processing("Transcribing"),
+        )
+        assertNotEquals(
+            PipelineState.Processing("Transcribing"),
+            PipelineState.Processing("Sending"),
+        )
+    }
+
+    @Test
+    fun `when expression is exhaustive over all states`() {
+        val states: List<PipelineState> = listOf(
+            PipelineState.Idle,
+            PipelineState.Recording,
+            PipelineState.Processing("test"),
+            PipelineState.Transcribed("text"),
+            PipelineState.Speaking("Maren"),
+            PipelineState.Error(PipelineError.MicBusy),
+        )
+        for (state in states) {
+            val label = when (state) {
+                is PipelineState.Idle -> "idle"
+                is PipelineState.Recording -> "recording"
+                is PipelineState.Processing -> "processing"
+                is PipelineState.Transcribed -> "transcribed"
+                is PipelineState.Speaking -> "speaking"
+                is PipelineState.Error -> "error"
+            }
+            assertTrue(label.isNotEmpty())
+        }
+    }
+}

--- a/app/src/test/java/dev/klazomenai/deckchat/ServiceEventTest.kt
+++ b/app/src/test/java/dev/klazomenai/deckchat/ServiceEventTest.kt
@@ -1,0 +1,32 @@
+package dev.klazomenai.deckchat
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ServiceEventTest {
+
+    @Test
+    fun `recording started is singleton`() {
+        assertTrue(ServiceEvent.RecordingStarted === ServiceEvent.RecordingStarted)
+    }
+
+    @Test
+    fun `recording stopped is singleton`() {
+        assertTrue(ServiceEvent.RecordingStopped === ServiceEvent.RecordingStopped)
+    }
+
+    @Test
+    fun `error carries pipeline error`() {
+        val event = ServiceEvent.Error(PipelineError.MicBusy)
+        assertEquals(PipelineError.MicBusy, event.error)
+    }
+
+    @Test
+    fun `error equality based on wrapped error`() {
+        assertEquals(
+            ServiceEvent.Error(PipelineError.PermissionDenied),
+            ServiceEvent.Error(PipelineError.PermissionDenied),
+        )
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,10 @@ preferenceKtx  = "1.2.1"
 securityCrypto = "1.1.0"    # final release — deprecated in 1.1.0; no further updates; used for EncryptedSharedPreferences
 sherpaOnnx     = "v1.12.29"  # JitPack requires 'v' prefix (matches upstream git tags)
 matrixRustSdk  = "26.03.19"
+material       = "1.12.0"
+constraintlayout = "2.2.1"
+lifecycle      = "2.9.1"
+activityKtx    = "1.10.1"
 coroutines     = "1.10.2"
 robolectric    = "4.16.1"
 espresso       = "3.7.0"
@@ -20,6 +24,11 @@ androidx-core-ktx        = { group = "androidx.core",                name = "cor
 androidx-appcompat       = { group = "androidx.appcompat",            name = "appcompat",         version.ref = "appcompat" }
 androidx-preference-ktx  = { group = "androidx.preference",          name = "preference-ktx",    version.ref = "preferenceKtx" }
 androidx-security-crypto = { group = "androidx.security",             name = "security-crypto",   version.ref = "securityCrypto" }
+google-material              = { group = "com.google.android.material", name = "material",                  version.ref = "material" }
+androidx-constraintlayout    = { group = "androidx.constraintlayout",  name = "constraintlayout",           version.ref = "constraintlayout" }
+androidx-lifecycle-viewmodel = { group = "androidx.lifecycle",          name = "lifecycle-viewmodel-ktx",    version.ref = "lifecycle" }
+androidx-lifecycle-runtime   = { group = "androidx.lifecycle",          name = "lifecycle-runtime-ktx",      version.ref = "lifecycle" }
+androidx-activity-ktx        = { group = "androidx.activity",           name = "activity-ktx",               version.ref = "activityKtx" }
 sherpa-onnx-android          = { group = "com.github.k2-fsa",        name = "sherpa-onnx",                 version.ref = "sherpaOnnx" }
 matrix-sdk-android           = { group = "org.matrix.rustcomponents", name = "sdk-android",                version.ref = "matrixRustSdk" }
 kotlinx-coroutines-android   = { group = "org.jetbrains.kotlinx",    name = "kotlinx-coroutines-android", version.ref = "coroutines" }


### PR DESCRIPTION
## Summary

- Add `PipelineState` sealed class hierarchy (Idle, Recording, Processing, Transcribed, Speaking, Error) and `PipelineError` categorisation for actionable UI feedback
- Add `MainViewModel` with `StateFlow<PipelineState>` for reactive UI updates, collecting `ServiceEvent` from `RecordingService` companion SharedFlow
- Replace empty `MainActivity` with `CoordinatorLayout` showing colour-coded state indicator dot, state label, and settings FAB
- Migrate theme from `Theme.AppCompat.DayNight.NoActionBar` to `Theme.MaterialComponents.DayNight.NoActionBar` with nautical colour palette
- Add Material Components, ConstraintLayout, Lifecycle ViewModel/Runtime, and Activity KTX dependencies
- Emit typed `ServiceEvent` errors from `RecordingService` (permission denied, audio init failed, mic busy) instead of silent `stopSelf()`

## Test plan

- [x] `PipelineStateTest` — 12 tests: sealed class properties, equality, exhaustiveness
- [x] `MainViewModelTest` — 11 tests: initial state, toggle transitions, service event collection, reset
- [x] `ServiceEventTest` — 4 tests: singleton identity, error wrapping, equality
- [x] `./gradlew :app:compileDebugKotlin` — builds clean (warnings only from pre-existing `SecureStorage` deprecations)
- [ ] Manual: launch app, verify "Idle" state with grey indicator dot
- [ ] Manual: verify light/dark mode renders correctly

Refs #29
