### PR TITLE
fix(devenv): replace removed nixpkgs.config with local import 🐛

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -1,7 +1,17 @@
-{ pkgs, ... }:
+{ pkgs, inputs, ... }:
 
 let
-  androidComposition = pkgs.androidenv.composeAndroidPackages {
+  # Android SDK requires unfree + explicit license acceptance.
+  # devenv 1.11.x removed the nixpkgs.config module option, so we import
+  # our own pkgs instance with the required config.
+  androidPkgs = import inputs.nixpkgs {
+    system = pkgs.stdenv.hostPlatform.system;
+    config = {
+      allowUnfree = true;
+      android_sdk.accept_license = true;
+    };
+  };
+  androidComposition = androidPkgs.androidenv.composeAndroidPackages {
     buildToolsVersions = [ "36.0.0" ];
     platformVersions = [ "35" "36" ];
     includeNDK = false;
@@ -14,10 +24,6 @@ let
 in
 
 {
-  # Android SDK has an unfree license; explicit license acceptance required by androidenv
-  nixpkgs.config.allowUnfree = true;
-  nixpkgs.config.android_sdk.accept_license = true;
-
   languages.java = {
     enable = true;
     jdk.package = pkgs.jdk17;


### PR DESCRIPTION
## Summary

- Replace removed `nixpkgs.config.allowUnfree` and `nixpkgs.config.android_sdk.accept_license` module options with a locally imported `pkgs` instance via `inputs.nixpkgs`
- devenv 1.11.x removed the `nixpkgs.config` module option, breaking `devenv shell` entirely

## Test plan

- [x] `devenv shell -- echo "works"` — enters shell without errors
- [x] `devenv shell -- bash -c './gradlew :app:compileDebugKotlin'` — builds successfully
- [x] `devenv shell -- bash -c './gradlew :app:testDebugUnitTest'` — all tests pass
- [ ] `emulator` script launches AVD from within devenv shell
- [ ] `install-debug` installs APK to emulator

Refs #76
