### PR TITLE
feat(ui): add runtime permission request flows for microphone ⛵

### DIFF
--- a/app/src/main/java/dev/klazomenai/deckchat/MainActivity.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/MainActivity.kt
@@ -1,12 +1,19 @@
 package dev.klazomenai.deckchat
 
+import android.Manifest
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.graphics.drawable.GradientDrawable
+import android.net.Uri
 import android.os.Bundle
+import android.provider.Settings
 import android.view.View
 import android.widget.TextView
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -17,6 +24,18 @@ import kotlinx.coroutines.launch
 class MainActivity : AppCompatActivity() {
 
     private val viewModel: MainViewModel by viewModels()
+
+    private val requestAudioPermission = registerForActivityResult(
+        ActivityResultContracts.RequestPermission(),
+    ) { granted ->
+        if (granted) {
+            startRecordingService()
+        } else if (!ActivityCompat.shouldShowRequestPermissionRationale(this, Manifest.permission.RECORD_AUDIO)) {
+            viewModel.setState(PipelineState.Error(PipelineError.PermissionPermanentlyDenied))
+        } else {
+            viewModel.setState(PipelineState.Error(PipelineError.PermissionDenied))
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -39,6 +58,67 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
+    /**
+     * Called by UI controls (FAB, headset) to initiate recording.
+     * Checks RECORD_AUDIO permission before starting the service.
+     */
+    fun onRecordRequested() {
+        val state = viewModel.state.value
+        if (state !is PipelineState.Idle && state !is PipelineState.Error) return
+        when {
+            ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO)
+                == PackageManager.PERMISSION_GRANTED -> {
+                startRecordingService()
+            }
+            ActivityCompat.shouldShowRequestPermissionRationale(this, Manifest.permission.RECORD_AUDIO) -> {
+                showPermissionRationale()
+            }
+            else -> {
+                requestAudioPermission.launch(Manifest.permission.RECORD_AUDIO)
+            }
+        }
+    }
+
+    private fun startRecordingService() {
+        val action = viewModel.toggleRecording() ?: return
+        val intent = Intent(this, RecordingService::class.java).apply {
+            this.action = action
+        }
+        if (action == RecordingService.ACTION_START) {
+            ContextCompat.startForegroundService(this, intent)
+        } else {
+            startService(intent)
+        }
+    }
+
+    /** Stop recording — called directly, no permission check needed. */
+    fun onStopRequested() {
+        val action = viewModel.requestStop() ?: return
+        startService(Intent(this, RecordingService::class.java).apply {
+            this.action = action
+        })
+    }
+
+    private fun showPermissionRationale() {
+        AlertDialog.Builder(this)
+            .setTitle(getString(R.string.permission_rationale_title))
+            .setMessage(getString(R.string.permission_rationale_message))
+            .setPositiveButton(getString(R.string.permission_rationale_grant)) { _, _ ->
+                requestAudioPermission.launch(Manifest.permission.RECORD_AUDIO)
+            }
+            .setNegativeButton(getString(R.string.permission_rationale_deny)) { _, _ ->
+                viewModel.setState(PipelineState.Error(PipelineError.PermissionDenied))
+            }
+            .show()
+    }
+
+    /** Opens the app's system settings page for manual permission grant. */
+    private fun openAppSettings() {
+        startActivity(Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+            data = Uri.fromParts("package", packageName, null)
+        })
+    }
+
     private fun updateStateUi(
         state: PipelineState,
         label: TextView,
@@ -50,7 +130,7 @@ class MainActivity : AppCompatActivity() {
             is PipelineState.Processing -> state.stage to R.color.state_processing
             is PipelineState.Transcribed -> getString(R.string.state_transcribed) to R.color.state_transcribed
             is PipelineState.Speaking -> getString(R.string.state_speaking, state.crewName) to R.color.state_speaking
-            is PipelineState.Error -> getString(R.string.state_error) to R.color.state_error
+            is PipelineState.Error -> errorText(state.error) to R.color.state_error
         }
 
         label.text = text
@@ -60,5 +140,33 @@ class MainActivity : AppCompatActivity() {
             background.mutate()
             background.setColor(color)
         }
+
+        // Handle permission error states with actionable dialogs
+        if (state is PipelineState.Error) {
+            when (state.error) {
+                is PipelineError.PermissionPermanentlyDenied -> {
+                    showPermanentDenialDialog()
+                }
+                else -> { /* Other errors handled by #32 */ }
+            }
+        }
+    }
+
+    private fun errorText(error: PipelineError): String = when (error) {
+        is PipelineError.PermissionDenied -> getString(R.string.error_permission_denied)
+        is PipelineError.PermissionPermanentlyDenied -> getString(R.string.error_permission_permanently_denied)
+        else -> getString(R.string.state_error)
+    }
+
+    private fun showPermanentDenialDialog() {
+        AlertDialog.Builder(this)
+            .setTitle(getString(R.string.permission_settings_title))
+            .setMessage(getString(R.string.permission_settings_message))
+            .setPositiveButton(getString(R.string.permission_settings_open)) { _, _ ->
+                openAppSettings()
+            }
+            .setNegativeButton(getString(R.string.permission_rationale_deny), null)
+            .setOnDismissListener { viewModel.resetToIdle() }
+            .show()
     }
 }

--- a/app/src/main/java/dev/klazomenai/deckchat/MainViewModel.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/MainViewModel.kt
@@ -47,6 +47,18 @@ class MainViewModel : ViewModel() {
         }
     }
 
+    /**
+     * Request stop — only returns ACTION_STOP when currently recording.
+     * Does not mutate state for non-recording states (unlike [toggleRecording]).
+     */
+    fun requestStop(): String? {
+        return if (_state.value is PipelineState.Recording) {
+            RecordingService.ACTION_STOP
+        } else {
+            null
+        }
+    }
+
     /** Reset to idle — used after error display or TTS completion. */
     fun resetToIdle() {
         _state.value = PipelineState.Idle

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,6 +18,21 @@
     <string name="state_speaking">%1$s is speaking</string>
     <string name="state_error">Error</string>
 
+    <!-- Permission errors -->
+    <string name="error_permission_denied">Microphone permission required</string>
+    <string name="error_permission_permanently_denied">Enable microphone in Settings</string>
+
+    <!-- Permission rationale dialog -->
+    <string name="permission_rationale_title">Microphone access</string>
+    <string name="permission_rationale_message">DeckChat needs microphone access to capture voice messages for the crew. Audio is temporarily stored on your device and only sent when you choose to share it.</string>
+    <string name="permission_rationale_grant">Grant</string>
+    <string name="permission_rationale_deny">Not now</string>
+
+    <!-- Permission settings dialog (permanent denial) -->
+    <string name="permission_settings_title">Permission required</string>
+    <string name="permission_settings_message">Microphone permission was permanently denied. Please enable it in the app settings to use voice recording.</string>
+    <string name="permission_settings_open">Open Settings</string>
+
     <!-- Content descriptions -->
     <string name="cd_settings">Settings</string>
 </resources>

--- a/app/src/test/java/dev/klazomenai/deckchat/MainViewModelTest.kt
+++ b/app/src/test/java/dev/klazomenai/deckchat/MainViewModelTest.kt
@@ -130,4 +130,64 @@ class MainViewModelTest {
         assertTrue(state is PipelineState.Error)
         assertEquals(PipelineError.PermissionDenied, (state as PipelineState.Error).error)
     }
+
+    @Test
+    fun `setState with PermissionDenied sets error state`() {
+        val viewModel = MainViewModel()
+        viewModel.setState(PipelineState.Error(PipelineError.PermissionDenied))
+        val state = viewModel.state.value
+        assertTrue(state is PipelineState.Error)
+        assertEquals(PipelineError.PermissionDenied, (state as PipelineState.Error).error)
+    }
+
+    @Test
+    fun `setState with PermissionPermanentlyDenied sets error state`() {
+        val viewModel = MainViewModel()
+        viewModel.setState(PipelineState.Error(PipelineError.PermissionPermanentlyDenied))
+        val state = viewModel.state.value
+        assertTrue(state is PipelineState.Error)
+        assertEquals(PipelineError.PermissionPermanentlyDenied, (state as PipelineState.Error).error)
+    }
+
+    @Test
+    fun `resetToIdle after permission denial returns to idle`() {
+        val viewModel = MainViewModel()
+        viewModel.setState(PipelineState.Error(PipelineError.PermissionPermanentlyDenied))
+        viewModel.resetToIdle()
+        assertEquals(PipelineState.Idle, viewModel.state.value)
+    }
+
+    @Test
+    fun `requestStop from recording returns ACTION_STOP`() {
+        val viewModel = MainViewModel()
+        viewModel.setState(PipelineState.Recording)
+        val action = viewModel.requestStop()
+        assertEquals(RecordingService.ACTION_STOP, action)
+    }
+
+    @Test
+    fun `requestStop from idle returns null without state change`() {
+        val viewModel = MainViewModel()
+        val action = viewModel.requestStop()
+        assertNull(action)
+        assertEquals(PipelineState.Idle, viewModel.state.value)
+    }
+
+    @Test
+    fun `requestStop from error returns null without state change`() {
+        val viewModel = MainViewModel()
+        viewModel.setState(PipelineState.Error(PipelineError.PermissionDenied))
+        val action = viewModel.requestStop()
+        assertNull(action)
+        assertTrue(viewModel.state.value is PipelineState.Error)
+    }
+
+    @Test
+    fun `toggleRecording from permission error returns ACTION_START`() {
+        val viewModel = MainViewModel()
+        viewModel.setState(PipelineState.Error(PipelineError.PermissionDenied))
+        val action = viewModel.toggleRecording()
+        assertEquals(RecordingService.ACTION_START, action)
+        assertEquals(PipelineState.Recording, viewModel.state.value)
+    }
 }


### PR DESCRIPTION
## Summary

- Add three-tier RECORD_AUDIO permission handling: direct grant, rationale dialog, permanent denial with Settings deep link
- Register `ActivityResultContracts.RequestPermission` callback that routes to `startRecordingService()` on grant or sets typed error state on denial
- Add `onRecordRequested()` entry point that checks permission before starting `RecordingService`, guarded to only proceed from Idle/Error states
- Add `requestStop()` to MainViewModel for safe stop without state mutation (unlike `toggleRecording()`)
- Show per-error-type labels for permission states (PermissionDenied, PermissionPermanentlyDenied) instead of generic "Error"
- Rationale "Not now" sets PermissionDenied error state; permanent denial dialog resets to Idle on dismiss
- BLUETOOTH_CONNECT already handled by `DeckChatAudioManager` with lazy check + speaker fallback

## Test plan

- [x] 7 new unit tests: permission denied/permanently denied state transitions, reset after denial, toggle from permission error, requestStop from recording/idle/error
- [x] All 16 existing unit tests pass (23 total)
- [x] Build compiles clean
- [x] CI green (build + instrumented tests)
- [ ] Manual: fresh install, tap record, see permission dialog — deferred to #78 (emulator stability)
- [ ] Manual: deny → rationale → deny again → Settings deep link — deferred to #78
- [ ] Manual: grant → recording starts — deferred to #78

## Acceptance criteria (#34)

- [x] Permissions are requested before use, not after failure — `onRecordRequested()` checks before `startRecordingService()`
- [x] Rationale dialog explains why the permission is needed — `showPermissionRationale()` with descriptive message
- [x] Permanent denial shows guidance to open Settings — `showPermanentDenialDialog()` with `openAppSettings()` deep link
- [x] App degrades gracefully if permission is denied — BLUETOOTH_CONNECT already falls back to speaker in `DeckChatAudioManager`

Refs #34
