### PR TITLE
feat(ui): add on-screen push-to-talk FAB ⛵

### DIFF
--- a/app/src/main/java/dev/klazomenai/deckchat/MainActivity.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/MainActivity.kt
@@ -44,15 +44,24 @@ class MainActivity : AppCompatActivity() {
         val stateLabel = findViewById<TextView>(R.id.state_label)
         val stateIndicator = findViewById<View>(R.id.state_indicator)
         val settingsFab = findViewById<FloatingActionButton>(R.id.settings_fab)
+        val pttFab = findViewById<FloatingActionButton>(R.id.ptt_fab)
 
         settingsFab.setOnClickListener {
             startActivity(Intent(this, SettingsActivity::class.java))
+        }
+
+        pttFab.setOnClickListener {
+            when (viewModel.state.value) {
+                is PipelineState.Recording -> onStopRequested()
+                else -> onRecordRequested()
+            }
         }
 
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.state.collect { state ->
                     updateStateUi(state, stateLabel, stateIndicator)
+                    updatePttFab(state, pttFab)
                 }
             }
         }
@@ -148,6 +157,26 @@ class MainActivity : AppCompatActivity() {
                     showPermanentDenialDialog()
                 }
                 else -> { /* Other errors handled by #32 */ }
+            }
+        }
+    }
+
+    private fun updatePttFab(state: PipelineState, fab: FloatingActionButton) {
+        when (state) {
+            is PipelineState.Recording -> {
+                fab.setImageResource(R.drawable.ic_stop)
+                fab.contentDescription = getString(R.string.cd_ptt_stop)
+                fab.isEnabled = true
+            }
+            is PipelineState.Processing, is PipelineState.Speaking, is PipelineState.Transcribed -> {
+                fab.setImageResource(android.R.drawable.ic_btn_speak_now)
+                fab.contentDescription = getString(R.string.cd_ptt_start)
+                fab.isEnabled = false
+            }
+            else -> {
+                fab.setImageResource(android.R.drawable.ic_btn_speak_now)
+                fab.contentDescription = getString(R.string.cd_ptt_start)
+                fab.isEnabled = true
             }
         }
     }

--- a/app/src/main/res/drawable/ic_stop.xml
+++ b/app/src/main/res/drawable/ic_stop.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/white" />
+    <size android:width="24dp" android:height="24dp" />
+</shape>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -33,6 +33,18 @@
 
     </LinearLayout>
 
+    <!-- Push-to-talk FAB (bottom-center) -->
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/ptt_fab"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|center_horizontal"
+        android:layout_marginBottom="32dp"
+        android:contentDescription="@string/cd_ptt_start"
+        android:src="@android:drawable/ic_btn_speak_now"
+        app:fabSize="normal"
+        app:backgroundTint="@color/teal" />
+
     <!-- Settings gear (top-right) -->
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/settings_fab"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,4 +35,6 @@
 
     <!-- Content descriptions -->
     <string name="cd_settings">Settings</string>
+    <string name="cd_ptt_start">Start recording</string>
+    <string name="cd_ptt_stop">Stop recording</string>
 </resources>


### PR DESCRIPTION
## Summary

- Add teal FAB at bottom-center of MainActivity for push-to-talk
- Toggle behaviour: tap to start recording (via `onRecordRequested()` permission flow), tap again to stop (via `onStopRequested()`)
- Icon swaps: mic icon (idle/error) ↔ pause icon (recording)
- FAB disabled during Processing and Speaking states to prevent pipeline interruption
- Content descriptions update per state for TalkBack accessibility

## Test plan

- [x] Existing `toggleRecording()` tests cover ViewModel state transitions (5 tests)
- [x] Existing `requestStop()` tests cover stop-only behaviour (3 tests)
- [x] Build compiles clean
- [x] All 23 existing unit tests pass
- [ ] Manual: tap FAB → permission prompt → recording starts (state indicator turns red)
- [ ] Manual: tap FAB again → recording stops → state transitions to Processing
- [ ] Manual: FAB disabled during Processing/Speaking
- [ ] Manual: TalkBack announces "Start recording" / "Stop recording"

Refs #30
