### PR TITLE
feat(ui): add recording duration timer and transcription text display ⛵

### DIFF
--- a/app/src/main/java/dev/klazomenai/deckchat/MainActivity.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/MainActivity.kt
@@ -57,6 +57,7 @@ class MainActivity : AppCompatActivity() {
         setContentView(R.layout.activity_main)
 
         val stateLabel = findViewById<TextView>(R.id.state_label)
+        val stateDetail = findViewById<TextView>(R.id.state_detail)
         val stateIndicator = findViewById<View>(R.id.state_indicator)
         val settingsFab = findViewById<FloatingActionButton>(R.id.settings_fab)
         val pttFab = findViewById<FloatingActionButton>(R.id.ptt_fab)
@@ -75,8 +76,20 @@ class MainActivity : AppCompatActivity() {
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.state.collect { state ->
-                    updateStateUi(state, stateLabel, stateIndicator)
+                    updateStateUi(state, stateLabel, stateDetail, stateIndicator)
                     updatePttFab(state, pttFab)
+                }
+            }
+        }
+
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.recordingDurationMs.collect { durationMs ->
+                    if (viewModel.state.value is PipelineState.Recording && durationMs > 0L) {
+                        val seconds = durationMs / 1000.0
+                        val formatted = String.format(java.util.Locale.ROOT, "%.1fs", seconds)
+                        stateLabel.text = getString(R.string.state_recording_duration, formatted)
+                    }
                 }
             }
         }
@@ -146,6 +159,7 @@ class MainActivity : AppCompatActivity() {
     private fun updateStateUi(
         state: PipelineState,
         label: TextView,
+        detail: TextView,
         indicator: View,
     ) {
         val (text, colorRes) = when (state) {
@@ -155,6 +169,18 @@ class MainActivity : AppCompatActivity() {
             is PipelineState.Transcribed -> getString(R.string.state_transcribed) to R.color.state_transcribed
             is PipelineState.Speaking -> getString(R.string.state_speaking, state.crewName) to R.color.state_speaking
             is PipelineState.Error -> errorText(state.error) to R.color.state_error
+        }
+
+        // Show transcription text in detail view when available
+        when (state) {
+            is PipelineState.Transcribed -> {
+                detail.text = state.text
+                detail.visibility = View.VISIBLE
+            }
+            else -> {
+                detail.text = ""
+                detail.visibility = View.GONE
+            }
         }
 
         // Crossfade text label: fade out, swap text, fade in

--- a/app/src/main/java/dev/klazomenai/deckchat/MainViewModel.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/MainViewModel.kt
@@ -37,14 +37,24 @@ class MainViewModel(
     private val _state = MutableStateFlow<PipelineState>(PipelineState.Idle)
     val state: StateFlow<PipelineState> = _state.asStateFlow()
 
+    private val _recordingDurationMs = MutableStateFlow(0L)
+    val recordingDurationMs: StateFlow<Long> = _recordingDurationMs.asStateFlow()
+
     private var pendingResponse: CompletableDeferred<CrewMessage>? = null
 
     init {
         viewModelScope.launch {
             RecordingService.serviceEvents.collect { event ->
                 when (event) {
-                    is ServiceEvent.RecordingStarted -> _state.value = PipelineState.Recording
+                    is ServiceEvent.RecordingStarted -> {
+                        _recordingDurationMs.value = 0L
+                        _state.value = PipelineState.Recording
+                    }
+                    is ServiceEvent.RecordingProgress -> {
+                        _recordingDurationMs.value = event.durationMs
+                    }
                     is ServiceEvent.RecordingStopped -> {
+                        _recordingDurationMs.value = 0L
                         _state.value = PipelineState.Processing("Transcribing")
                         runPipeline()
                     }

--- a/app/src/main/java/dev/klazomenai/deckchat/RecordingService.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/RecordingService.kt
@@ -132,12 +132,19 @@ class RecordingService : Service() {
             return
         }
 
+        val startTimeMs = System.currentTimeMillis()
         recordingThread = Thread {
             val buffer = ByteArray(bufferSize)
+            var lastProgressMs = startTimeMs
             while (isRecording) {
                 val read = audioRecord?.read(buffer, 0, buffer.size) ?: -1
                 if (read > 0) {
                     audioBuffer.add(buffer.copyOf(read))
+                    val now = System.currentTimeMillis()
+                    if (now - lastProgressMs >= PROGRESS_INTERVAL_MS) {
+                        lastProgressMs = now
+                        emitEvent(ServiceEvent.RecordingProgress(now - startTimeMs))
+                    }
                 } else if (read < 0) {
                     // AudioRecord error — stop recording and emit error
                     isRecording = false
@@ -248,6 +255,7 @@ class RecordingService : Service() {
         private const val SAMPLE_RATE = 16000
         private const val RECORDING_FILENAME = "recording.pcm"
         private const val THREAD_JOIN_TIMEOUT_MS = 2000L
+        private const val PROGRESS_INTERVAL_MS = 500L
 
         /**
          * App-wide listener. Set from Activity/Application before service starts.

--- a/app/src/main/java/dev/klazomenai/deckchat/ServiceEvent.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/ServiceEvent.kt
@@ -10,6 +10,9 @@ sealed class ServiceEvent {
     /** Recording has started successfully. */
     data object RecordingStarted : ServiceEvent()
 
+    /** Periodic progress during recording — emitted ~every 500ms. */
+    data class RecordingProgress(val durationMs: Long) : ServiceEvent()
+
     /** Recording stopped normally — PCM file is ready. */
     data object RecordingStopped : ServiceEvent()
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -31,6 +31,20 @@
             android:textSize="18sp"
             android:textStyle="bold" />
 
+        <!-- Detail text — transcription result, shown below state_label -->
+        <TextView
+            android:id="@+id/state_detail"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:textSize="14sp"
+            android:visibility="gone"
+            android:gravity="center"
+            android:maxLines="3"
+            android:ellipsize="end"
+            android:paddingStart="24dp"
+            android:paddingEnd="24dp" />
+
     </LinearLayout>
 
     <!-- Push-to-talk FAB (bottom-center) -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
     <!-- Pipeline state labels -->
     <string name="state_idle">Idle</string>
     <string name="state_recording">Recording</string>
+    <string name="state_recording_duration">Recording: %1$s</string>
     <string name="state_processing">Processing</string>
     <string name="state_transcribed">Transcribed</string>
     <string name="state_speaking">%1$s is speaking</string>

--- a/app/src/test/java/dev/klazomenai/deckchat/MainViewModelTest.kt
+++ b/app/src/test/java/dev/klazomenai/deckchat/MainViewModelTest.kt
@@ -213,4 +213,56 @@ class MainViewModelTest {
         assertEquals(RecordingService.ACTION_START, action)
         assertEquals(PipelineState.Recording, viewModel.state.value)
     }
+
+    // --- Recording duration ---
+
+    @Test
+    fun `recording progress updates duration flow`() = runTest {
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        RecordingService.emitEvent(ServiceEvent.RecordingProgress(1500L))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(1500L, viewModel.recordingDurationMs.value)
+    }
+
+    @Test
+    fun `recording started resets duration to zero`() = runTest {
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        RecordingService.emitEvent(ServiceEvent.RecordingProgress(3000L))
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals(3000L, viewModel.recordingDurationMs.value)
+
+        RecordingService.emitEvent(ServiceEvent.RecordingStarted)
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals(0L, viewModel.recordingDurationMs.value)
+    }
+
+    @Test
+    fun `recording stopped resets duration to zero`() = runTest {
+        val viewModel = createViewModel(sttResult = "")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        RecordingService.emitEvent(ServiceEvent.RecordingProgress(2000L))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        RecordingService.emitEvent(ServiceEvent.RecordingStopped)
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals(0L, viewModel.recordingDurationMs.value)
+    }
+
+    @Test
+    fun `recording progress does not change pipeline state`() = runTest {
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.setState(PipelineState.Recording)
+        RecordingService.emitEvent(ServiceEvent.RecordingProgress(500L))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(PipelineState.Recording, viewModel.state.value)
+    }
 }

--- a/app/src/test/java/dev/klazomenai/deckchat/ServiceEventTest.kt
+++ b/app/src/test/java/dev/klazomenai/deckchat/ServiceEventTest.kt
@@ -1,6 +1,7 @@
 package dev.klazomenai.deckchat
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -27,6 +28,24 @@ class ServiceEventTest {
         assertEquals(
             ServiceEvent.Error(PipelineError.PermissionDenied),
             ServiceEvent.Error(PipelineError.PermissionDenied),
+        )
+    }
+
+    @Test
+    fun `recording progress carries duration`() {
+        val event = ServiceEvent.RecordingProgress(1500L)
+        assertEquals(1500L, event.durationMs)
+    }
+
+    @Test
+    fun `recording progress equality based on duration`() {
+        assertEquals(
+            ServiceEvent.RecordingProgress(1000L),
+            ServiceEvent.RecordingProgress(1000L),
+        )
+        assertNotEquals(
+            ServiceEvent.RecordingProgress(1000L),
+            ServiceEvent.RecordingProgress(2000L),
         )
     }
 }


### PR DESCRIPTION
## Summary

- Emit `RecordingProgress(durationMs)` every ~500ms from `RecordingService` recording thread
- `MainViewModel` exposes `recordingDurationMs: StateFlow<Long>` (separate from pipeline state)
- `MainActivity` collects duration flow and updates state label to "Recording: 3.2s" during capture
- New `state_detail` `TextView` below state label shows actual STT transcription text in `Transcribed` state
- 6 new tests (2 ServiceEvent + 4 MainViewModel), 96 total passing

## Test plan

- [x] `./gradlew :app:compileDebugKotlin` — builds clean
- [x] `./gradlew :app:testDebugUnitTest` — 96 tests pass (0 failures)
- [ ] Manual: record → see "Recording: X.Xs" incrementing
- [ ] Manual: see transcribed text flash below state label after STT
- [ ] Manual: verify dark mode renders correctly

Refs #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)