### PR TITLE
fix(ui): surface specific error messages for all pipeline failure types 🐛

### DIFF
--- a/app/src/main/java/dev/klazomenai/deckchat/MainActivity.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/MainActivity.kt
@@ -171,11 +171,26 @@ class MainActivity : AppCompatActivity() {
             is PipelineState.Error -> errorText(state.error) to R.color.state_error
         }
 
-        // Show transcription text in detail view when available
+        // Show detail text for transcription results and error messages
         when (state) {
             is PipelineState.Transcribed -> {
                 detail.text = state.text
                 detail.visibility = View.VISIBLE
+            }
+            is PipelineState.Error -> {
+                val detailMsg = when (val err = state.error) {
+                    is PipelineError.SttFailed -> err.message
+                    is PipelineError.TtsFailed -> err.message
+                    is PipelineError.MatrixFailed -> err.message
+                    else -> null
+                }
+                if (detailMsg != null) {
+                    detail.text = detailMsg
+                    detail.visibility = View.VISIBLE
+                } else {
+                    detail.text = ""
+                    detail.visibility = View.GONE
+                }
             }
             else -> {
                 detail.text = ""
@@ -272,7 +287,13 @@ class MainActivity : AppCompatActivity() {
     private fun errorText(error: PipelineError): String = when (error) {
         is PipelineError.PermissionDenied -> getString(R.string.error_permission_denied)
         is PipelineError.PermissionPermanentlyDenied -> getString(R.string.error_permission_permanently_denied)
-        else -> getString(R.string.state_error)
+        is PipelineError.MicBusy -> getString(R.string.error_mic_busy)
+        is PipelineError.AudioInitFailed -> getString(R.string.error_audio_init_failed)
+        is PipelineError.ModelMissing -> getString(R.string.error_model_missing)
+        is PipelineError.BluetoothLost -> getString(R.string.error_bluetooth_lost)
+        is PipelineError.SttFailed -> getString(R.string.error_stt_failed, error.message)
+        is PipelineError.TtsFailed -> getString(R.string.error_tts_failed, error.message)
+        is PipelineError.MatrixFailed -> getString(R.string.error_matrix_failed, error.message)
     }
 
     private fun showPermanentDenialDialog() {

--- a/app/src/main/java/dev/klazomenai/deckchat/RecordingService.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/RecordingService.kt
@@ -184,7 +184,14 @@ class RecordingService : Service() {
         audioRecord?.release()
         audioRecord = null
 
-        val outputFile = writeBufferToFile()
+        val outputFile = try {
+            writeBufferToFile()
+        } catch (e: Exception) {
+            emitEvent(ServiceEvent.Error(PipelineError.AudioInitFailed))
+            stopForeground(STOP_FOREGROUND_REMOVE)
+            stopSelf()
+            return
+        }
         emitEvent(ServiceEvent.RecordingStopped)
         listener?.onRecordingComplete(outputFile)
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,9 +21,16 @@
     <string name="state_speaking">%1$s is speaking</string>
     <string name="state_error">Error</string>
 
-    <!-- Permission errors -->
+    <!-- Error messages -->
     <string name="error_permission_denied">Microphone permission required</string>
     <string name="error_permission_permanently_denied">Enable microphone in Settings</string>
+    <string name="error_mic_busy">Microphone is in use by another app</string>
+    <string name="error_audio_init_failed">Audio system failed to initialise</string>
+    <string name="error_model_missing">Speech model not found — reinstall the app</string>
+    <string name="error_bluetooth_lost">Bluetooth headset disconnected</string>
+    <string name="error_stt_failed">Transcription failed: %1$s</string>
+    <string name="error_tts_failed">Speech synthesis failed: %1$s</string>
+    <string name="error_matrix_failed">Matrix connection failed: %1$s</string>
 
     <!-- Permission rationale dialog -->
     <string name="permission_rationale_title">Microphone access</string>


### PR DESCRIPTION
## Summary

- Replace generic "Error" label with dedicated strings for all 9 `PipelineError` types
- `errorText()` is now exhaustive (no `else` branch) — compiler enforces coverage
- Show error detail in `state_detail` `TextView` for `SttFailed`, `TtsFailed`, `MatrixFailed`
- Wrap `RecordingService.writeBufferToFile()` in try/catch to prevent silent service crash on disk write failure

## Test plan

- [x] `./gradlew :app:compileDebugKotlin` — builds clean
- [x] `./gradlew :app:testDebugUnitTest` — 96 tests pass (0 failures)
- [ ] Manual: trigger permission denial → see "Microphone permission required"
- [ ] Manual: verify each error type shows specific message (not generic "Error")

Refs #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)