### PR TITLE
feat(ui): implement first-run onboarding wizard ⛵

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -40,6 +40,8 @@
 
         <activity android:name=".SettingsActivity" />
 
+        <activity android:name=".OnboardingActivity" />
+
         <!-- Headset button → start/stop RecordingService.
              exported=true required: system delivers ACTION_MEDIA_BUTTON from outside the app.
              See issue #17 for MediaSession spike (future replacement). -->

--- a/app/src/main/java/dev/klazomenai/deckchat/MainActivity.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/MainActivity.kt
@@ -33,8 +33,10 @@ class MainActivity : AppCompatActivity() {
         val ttsEngine = SherpaOnnxTtsEngine(appContext)
         val matrixClient: MatrixClient? = if (storage.hasSession()) RustMatrixClient(appContext, storage) else null
         val roomId = storage.roomId
+        val voiceProfile = storage.voiceProfile ?: "maren"
         MainViewModel.Factory(sttEngine, ttsEngine, matrixClient, roomId,
             audioFileProvider = { File(appContext.cacheDir, "recording.pcm") },
+            defaultCrew = voiceProfile,
         )
     }
     private var currentIndicatorColor: Int = 0
@@ -54,6 +56,13 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        if (!SecureStorage(this).onboardingComplete) {
+            startActivity(Intent(this, OnboardingActivity::class.java))
+            finish()
+            return
+        }
+
         setContentView(R.layout.activity_main)
 
         val stateLabel = findViewById<TextView>(R.id.state_label)

--- a/app/src/main/java/dev/klazomenai/deckchat/MainViewModel.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/MainViewModel.kt
@@ -31,6 +31,7 @@ class MainViewModel(
     private val matrixClient: MatrixClient?,
     private val roomId: String?,
     private val audioFileProvider: () -> File,
+    private val defaultCrew: String = DEFAULT_CREW,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : ViewModel() {
 
@@ -135,9 +136,9 @@ class MainViewModel(
                     ttsEngine.speak(response.crewName, response.body)
                 } else {
                     // Local echo: TTS reads back transcription with default crew
-                    val displayName = CrewRegistry.lookup(DEFAULT_CREW).displayName
+                    val displayName = CrewRegistry.lookup(defaultCrew).displayName
                     _state.value = PipelineState.Speaking(displayName)
-                    ttsEngine.speak(DEFAULT_CREW, text)
+                    ttsEngine.speak(defaultCrew, text)
                 }
 
                 _state.value = PipelineState.Idle
@@ -223,12 +224,13 @@ class MainViewModel(
         private val matrixClient: MatrixClient?,
         private val roomId: String?,
         private val audioFileProvider: () -> File,
+        private val defaultCrew: String = DEFAULT_CREW,
         private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
     ) : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
             if (modelClass.isAssignableFrom(MainViewModel::class.java)) {
-                return MainViewModel(sttEngine, ttsEngine, matrixClient, roomId, audioFileProvider, ioDispatcher) as T
+                return MainViewModel(sttEngine, ttsEngine, matrixClient, roomId, audioFileProvider, defaultCrew, ioDispatcher) as T
             }
             throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
         }

--- a/app/src/main/java/dev/klazomenai/deckchat/OnboardingActivity.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/OnboardingActivity.kt
@@ -1,0 +1,236 @@
+package dev.klazomenai.deckchat
+
+import android.Manifest
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
+import android.os.Bundle
+import android.view.View
+import android.widget.Button
+import android.widget.EditText
+import android.widget.ProgressBar
+import android.widget.RadioGroup
+import android.widget.TextView
+import androidx.activity.OnBackPressedCallback
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class OnboardingActivity : AppCompatActivity() {
+
+    private lateinit var storage: SecureStorage
+    private var currentStep = 0
+
+    private lateinit var stepViews: List<View>
+    private lateinit var btnBack: Button
+    private lateinit var btnNext: Button
+    private lateinit var stepIndicator: TextView
+
+    // Permission launchers — must be registered at class level
+    private val requestAudioPermission = registerForActivityResult(
+        ActivityResultContracts.RequestPermission(),
+    ) { updatePermissionStatus() }
+
+    private val requestBluetoothPermission = registerForActivityResult(
+        ActivityResultContracts.RequestPermission(),
+    ) { updatePermissionStatus() }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_onboarding)
+
+        storage = SecureStorage(this)
+
+        stepIndicator = findViewById(R.id.step_indicator)
+        btnBack = findViewById(R.id.btn_back)
+        btnNext = findViewById(R.id.btn_next)
+
+        stepViews = listOf(
+            findViewById(R.id.step_login),
+            findViewById(R.id.step_voice),
+            findViewById(R.id.step_permissions),
+            findViewById(R.id.step_bluetooth),
+        )
+
+        if (savedInstanceState != null) {
+            currentStep = savedInstanceState.getInt(KEY_CURRENT_STEP, 0)
+        }
+
+        setupPermissionsStep()
+        showStep(currentStep)
+
+        btnBack.setOnClickListener { goBack() }
+        btnNext.setOnClickListener { goNext() }
+
+        onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                goBack()
+            }
+        })
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putInt(KEY_CURRENT_STEP, currentStep)
+    }
+
+    private fun showStep(step: Int) {
+        stepViews.forEachIndexed { i, view ->
+            view.visibility = if (i == step) View.VISIBLE else View.GONE
+        }
+
+        stepIndicator.text = getString(R.string.onboarding_step_indicator, step + 1, TOTAL_STEPS)
+        btnBack.visibility = if (step > 0) View.VISIBLE else View.GONE
+        btnNext.text = if (step == LAST_STEP) getString(R.string.onboarding_finish) else getString(R.string.onboarding_next)
+        btnNext.isEnabled = true
+
+        if (step == STEP_PERMISSIONS) {
+            updatePermissionStatus()
+        }
+    }
+
+    private fun goBack() {
+        if (currentStep > 0) {
+            currentStep--
+            showStep(currentStep)
+        } else {
+            finish()
+        }
+    }
+
+    private fun goNext() {
+        when (currentStep) {
+            STEP_LOGIN -> validateAndLogin()
+            STEP_VOICE -> { saveVoiceProfile(); advanceStep() }
+            STEP_PERMISSIONS -> advanceStep()
+            STEP_BLUETOOTH -> finishOnboarding()
+        }
+    }
+
+    private fun advanceStep() {
+        if (currentStep < LAST_STEP) {
+            currentStep++
+            showStep(currentStep)
+        }
+    }
+
+    // --- Step 1: Login ---
+
+    private fun validateAndLogin() {
+        val homeserverInput = findViewById<EditText>(R.id.onboarding_homeserver_url)
+        val usernameInput = findViewById<EditText>(R.id.onboarding_username)
+        val passwordInput = findViewById<EditText>(R.id.onboarding_password)
+        val roomIdInput = findViewById<EditText>(R.id.onboarding_room_id)
+        val loginProgress = findViewById<ProgressBar>(R.id.login_progress)
+        val loginError = findViewById<TextView>(R.id.login_error)
+
+        val url = homeserverInput.text.toString().trim()
+        val username = usernameInput.text.toString().trim()
+        val password = passwordInput.text.toString().trim()
+        val roomId = roomIdInput.text.toString().trim()
+
+        if (url.isEmpty()) { homeserverInput.error = "Required"; return }
+        if (!url.startsWith("https://")) { homeserverInput.error = "Must start with https://"; return }
+        if (Uri.parse(url).host.isNullOrBlank()) { homeserverInput.error = "Invalid URL"; return }
+        if (username.isEmpty()) { usernameInput.error = "Required"; return }
+        if (password.isEmpty()) { passwordInput.error = "Required"; return }
+        if (roomId.isEmpty()) { roomIdInput.error = "Required"; return }
+
+        loginProgress.visibility = View.VISIBLE
+        loginError.visibility = View.GONE
+        btnNext.isEnabled = false
+
+        lifecycleScope.launch {
+            try {
+                withContext(Dispatchers.IO) {
+                    val client = RustMatrixClient(applicationContext, storage)
+                    client.login(url, username, password)
+                }
+                storage.roomId = roomId
+                loginProgress.visibility = View.GONE
+                advanceStep()
+            } catch (e: Exception) {
+                loginProgress.visibility = View.GONE
+                loginError.text = e.message ?: "Login failed"
+                loginError.visibility = View.VISIBLE
+                btnNext.isEnabled = true
+            }
+        }
+    }
+
+    // --- Step 2: Voice ---
+
+    private fun saveVoiceProfile() {
+        val radioGroup = findViewById<RadioGroup>(R.id.voice_radio_group)
+        storage.voiceProfile = when (radioGroup.checkedRadioButtonId) {
+            R.id.radio_crest -> "crest"
+            else -> "maren"
+        }
+    }
+
+    // --- Step 3: Permissions ---
+
+    private fun setupPermissionsStep() {
+        findViewById<Button>(R.id.btn_grant_audio).setOnClickListener {
+            requestAudioPermission.launch(Manifest.permission.RECORD_AUDIO)
+        }
+
+        val btButton = findViewById<Button>(R.id.btn_grant_bluetooth)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            btButton.setOnClickListener {
+                requestBluetoothPermission.launch(Manifest.permission.BLUETOOTH_CONNECT)
+            }
+        } else {
+            btButton.isEnabled = false
+            findViewById<TextView>(R.id.bt_permission_status).text =
+                getString(R.string.onboarding_permission_granted)
+        }
+    }
+
+    private fun updatePermissionStatus() {
+        val audioGranted = ContextCompat.checkSelfPermission(
+            this, Manifest.permission.RECORD_AUDIO,
+        ) == PackageManager.PERMISSION_GRANTED
+
+        findViewById<TextView>(R.id.audio_permission_status).text =
+            if (audioGranted) getString(R.string.onboarding_permission_granted)
+            else getString(R.string.onboarding_permission_required)
+
+        findViewById<Button>(R.id.btn_grant_audio).isEnabled = !audioGranted
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val btGranted = ContextCompat.checkSelfPermission(
+                this, Manifest.permission.BLUETOOTH_CONNECT,
+            ) == PackageManager.PERMISSION_GRANTED
+
+            findViewById<TextView>(R.id.bt_permission_status).text =
+                if (btGranted) getString(R.string.onboarding_permission_granted)
+                else getString(R.string.onboarding_permission_optional)
+
+            findViewById<Button>(R.id.btn_grant_bluetooth).isEnabled = !btGranted
+        }
+    }
+
+    // --- Step 4: Finish ---
+
+    private fun finishOnboarding() {
+        storage.onboardingComplete = true
+        startActivity(Intent(this, MainActivity::class.java))
+        finish()
+    }
+
+    companion object {
+        private const val STEP_LOGIN = 0
+        private const val STEP_VOICE = 1
+        private const val STEP_PERMISSIONS = 2
+        private const val STEP_BLUETOOTH = 3
+        private const val LAST_STEP = STEP_BLUETOOTH
+        private const val TOTAL_STEPS = 4
+        private const val KEY_CURRENT_STEP = "current_step"
+    }
+}

--- a/app/src/main/java/dev/klazomenai/deckchat/SecureStorage.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/SecureStorage.kt
@@ -67,6 +67,14 @@ class SecureStorage(
         get() = prefs.getString(KEY_ROOM_ID, null)
         set(value) = prefs.edit().putString(KEY_ROOM_ID, value).apply()
 
+    var voiceProfile: String?
+        get() = prefs.getString(KEY_VOICE_PROFILE, null)
+        set(value) = prefs.edit().putString(KEY_VOICE_PROFILE, value).apply()
+
+    var onboardingComplete: Boolean
+        get() = prefs.getBoolean(KEY_ONBOARDING_COMPLETE, false)
+        set(value) = prefs.edit().putBoolean(KEY_ONBOARDING_COMPLETE, value).apply()
+
     // --- Sensitive tokens (encrypted via TokenEncryptor) ---
 
     var accessToken: String?
@@ -195,6 +203,8 @@ class SecureStorage(
         private const val KEY_DEVICE_ID = "device_id"
         private const val KEY_SLIDING_SYNC_VERSION = "sliding_sync_version"
         private const val KEY_ROOM_ID = "room_id"
+        private const val KEY_VOICE_PROFILE = "voice_profile"
+        private const val KEY_ONBOARDING_COMPLETE = "onboarding_complete"
         private const val KEY_ACCESS_TOKEN = "access_token"
         private const val KEY_REFRESH_TOKEN = "refresh_token"
         private const val KEY_SQLITE_PASSPHRASE = "sqlite_passphrase"

--- a/app/src/main/res/layout/activity_onboarding.xml
+++ b/app/src/main/res/layout/activity_onboarding.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/step_indicator"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:padding="16dp"
+        android:textSize="14sp" />
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1">
+
+        <include
+            android:id="@+id/step_login"
+            layout="@layout/onboarding_step_login" />
+
+        <include
+            android:id="@+id/step_voice"
+            layout="@layout/onboarding_step_voice"
+            android:visibility="gone" />
+
+        <include
+            android:id="@+id/step_permissions"
+            layout="@layout/onboarding_step_permissions"
+            android:visibility="gone" />
+
+        <include
+            android:id="@+id/step_bluetooth"
+            layout="@layout/onboarding_step_bluetooth"
+            android:visibility="gone" />
+
+    </FrameLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="16dp">
+
+        <Button
+            android:id="@+id/btn_back"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/onboarding_back"
+            android:visibility="gone"
+            style="?attr/borderlessButtonStyle" />
+
+        <Button
+            android:id="@+id/btn_next"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/onboarding_next" />
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/onboarding_step_bluetooth.xml
+++ b/app/src/main/res/layout/onboarding_step_bluetooth.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="24dp">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/onboarding_bluetooth_title"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        android:layout_marginBottom="8dp" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/onboarding_bluetooth_guidance"
+        android:textSize="14sp"
+        android:lineSpacingExtra="4dp" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/onboarding_step_login.xml
+++ b/app/src/main/res/layout/onboarding_step_login.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="24dp">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/onboarding_login_title"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        android:layout_marginBottom="8dp" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/onboarding_login_subtitle"
+        android:textSize="14sp"
+        android:layout_marginBottom="16dp" />
+
+    <EditText
+        android:id="@+id/onboarding_homeserver_url"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/homeserver_url_hint"
+        android:inputType="textUri"
+        android:layout_marginBottom="8dp" />
+
+    <EditText
+        android:id="@+id/onboarding_username"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/onboarding_username_hint"
+        android:inputType="textNoSuggestions"
+        android:layout_marginBottom="8dp" />
+
+    <EditText
+        android:id="@+id/onboarding_password"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/onboarding_password_label"
+        android:inputType="textPassword"
+        android:layout_marginBottom="8dp" />
+
+    <EditText
+        android:id="@+id/onboarding_room_id"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/room_id_hint"
+        android:inputType="textNoSuggestions"
+        android:layout_marginBottom="16dp" />
+
+    <ProgressBar
+        android:id="@+id/login_progress"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:visibility="gone" />
+
+    <TextView
+        android:id="@+id/login_error"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textColor="@color/state_error"
+        android:visibility="gone" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/onboarding_step_permissions.xml
+++ b/app/src/main/res/layout/onboarding_step_permissions.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="24dp">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/onboarding_permissions_title"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        android:layout_marginBottom="8dp" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/onboarding_permissions_subtitle"
+        android:textSize="14sp"
+        android:layout_marginBottom="24dp" />
+
+    <Button
+        android:id="@+id/btn_grant_audio"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/onboarding_grant_audio"
+        android:layout_marginBottom="4dp" />
+
+    <TextView
+        android:id="@+id/audio_permission_status"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/onboarding_permission_required"
+        android:textSize="12sp"
+        android:layout_marginBottom="16dp" />
+
+    <Button
+        android:id="@+id/btn_grant_bluetooth"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/onboarding_grant_bluetooth"
+        android:layout_marginBottom="4dp" />
+
+    <TextView
+        android:id="@+id/bt_permission_status"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/onboarding_permission_optional"
+        android:textSize="12sp" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/onboarding_step_voice.xml
+++ b/app/src/main/res/layout/onboarding_step_voice.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="24dp">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/onboarding_voice_title"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        android:layout_marginBottom="8dp" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/onboarding_voice_subtitle"
+        android:textSize="14sp"
+        android:layout_marginBottom="24dp" />
+
+    <RadioGroup
+        android:id="@+id/voice_radio_group"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <RadioButton
+            android:id="@+id/radio_maren"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/onboarding_voice_maren"
+            android:checked="true"
+            android:padding="12dp" />
+
+        <RadioButton
+            android:id="@+id/radio_crest"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/onboarding_voice_crest"
+            android:padding="12dp" />
+
+    </RadioGroup>
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,6 +43,29 @@
     <string name="permission_settings_message">Microphone permission was permanently denied. Please enable it in the app settings to use voice recording.</string>
     <string name="permission_settings_open">Open Settings</string>
 
+    <!-- Onboarding -->
+    <string name="onboarding_step_indicator">Step %1$d of %2$d</string>
+    <string name="onboarding_next">Next</string>
+    <string name="onboarding_back">Back</string>
+    <string name="onboarding_finish">Finish</string>
+    <string name="onboarding_login_title">Connect to Matrix</string>
+    <string name="onboarding_login_subtitle">Enter your homeserver credentials</string>
+    <string name="onboarding_username_hint">\@user:example.com</string>
+    <string name="onboarding_password_label">Password</string>
+    <string name="onboarding_voice_title">Choose your voice</string>
+    <string name="onboarding_voice_subtitle">Select the crew member voice for responses</string>
+    <string name="onboarding_voice_maren">Maren \u2014 British English</string>
+    <string name="onboarding_voice_crest">Crest \u2014 American English</string>
+    <string name="onboarding_permissions_title">Permissions</string>
+    <string name="onboarding_permissions_subtitle">DeckChat needs these permissions to function</string>
+    <string name="onboarding_grant_audio">Grant microphone access</string>
+    <string name="onboarding_grant_bluetooth">Grant Bluetooth access</string>
+    <string name="onboarding_permission_granted">Granted</string>
+    <string name="onboarding_permission_required">Required</string>
+    <string name="onboarding_permission_optional">Optional</string>
+    <string name="onboarding_bluetooth_title">Bluetooth headset</string>
+    <string name="onboarding_bluetooth_guidance">For the best experience, pair a Bluetooth headset before using DeckChat.\n\nYou can use DeckChat without a headset \u2014 audio will play through the device speaker and record through the built\u2011in microphone.</string>
+
     <!-- Content descriptions -->
     <string name="cd_settings">Settings</string>
     <string name="cd_ptt_start">Start recording</string>

--- a/app/src/test/java/dev/klazomenai/deckchat/MainViewModelTest.kt
+++ b/app/src/test/java/dev/klazomenai/deckchat/MainViewModelTest.kt
@@ -39,6 +39,7 @@ class MainViewModelTest {
         sttResult: String = "",
         matrixClient: MatrixClient? = null,
         roomId: String? = null,
+        defaultCrew: String = "maren",
     ): MainViewModel {
         return MainViewModel(
             sttEngine = MockSttEngine(returnText = sttResult),
@@ -46,6 +47,7 @@ class MainViewModelTest {
             matrixClient = matrixClient,
             roomId = roomId,
             audioFileProvider = { audioFile },
+            defaultCrew = defaultCrew,
             ioDispatcher = testDispatcher,
         ).also { viewModels.add(it) }
     }
@@ -264,5 +266,28 @@ class MainViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(PipelineState.Recording, viewModel.state.value)
+    }
+
+    // --- Voice profile ---
+
+    @Test
+    fun `local echo uses configured voice profile`() = runTest {
+        val tts = MockTtsEngine()
+        val viewModel = MainViewModel(
+            sttEngine = MockSttEngine(returnText = "hello"),
+            ttsEngine = tts,
+            matrixClient = null,
+            roomId = null,
+            audioFileProvider = { audioFile },
+            defaultCrew = "crest",
+            ioDispatcher = testDispatcher,
+        ).also { viewModels.add(it) }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        RecordingService.emitEvent(ServiceEvent.RecordingStopped)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(1, tts.calls.size)
+        assertEquals("crest", tts.calls[0].crewName)
     }
 }

--- a/app/src/test/java/dev/klazomenai/deckchat/SecureStorageTest.kt
+++ b/app/src/test/java/dev/klazomenai/deckchat/SecureStorageTest.kt
@@ -112,4 +112,48 @@ class SecureStorageTest {
         assertEquals("@deckchat:example.com", storage.userId)
         assertEquals("ABCDEF", storage.deviceId)
     }
+
+    @Test
+    fun `voiceProfile defaults to null`() {
+        val storage = createStorage()
+        assertNull(storage.voiceProfile)
+    }
+
+    @Test
+    fun `voiceProfile round-trips`() {
+        val storage = createStorage()
+        storage.voiceProfile = "crest"
+        assertEquals("crest", storage.voiceProfile)
+    }
+
+    @Test
+    fun `onboardingComplete defaults to false`() {
+        val storage = createStorage()
+        assertFalse(storage.onboardingComplete)
+    }
+
+    @Test
+    fun `onboardingComplete round-trips`() {
+        val storage = createStorage()
+        storage.onboardingComplete = true
+        assertTrue(storage.onboardingComplete)
+    }
+
+    @Test
+    fun `clearSession does not clear onboardingComplete`() {
+        val storage = createStorage()
+        storage.onboardingComplete = true
+        storage.accessToken = "token"
+        storage.clearSession()
+        assertTrue(storage.onboardingComplete)
+    }
+
+    @Test
+    fun `clearSession does not clear voiceProfile`() {
+        val storage = createStorage()
+        storage.voiceProfile = "crest"
+        storage.accessToken = "token"
+        storage.clearSession()
+        assertEquals("crest", storage.voiceProfile)
+    }
 }


### PR DESCRIPTION
## Summary

- 4-step onboarding wizard: Matrix login, voice profile selection, permissions, Bluetooth guidance
- Single `OnboardingActivity` with view swapping (no fragments — matches existing architecture)
- Full Matrix login via `RustMatrixClient.login()` with inline progress/error
- Voice profile persisted in `SecureStorage.voiceProfile`, used by `MainViewModel` for local echo TTS
- `SecureStorage.onboardingComplete` flag for first-run detection
- Permission grants with live status (RECORD_AUDIO required, BLUETOOTH_CONNECT optional on API 31+)
- Back navigation, input validation, config change survival via `onSaveInstanceState`

## Test plan

- [x] `./gradlew :app:compileDebugKotlin` — builds clean
- [x] `./gradlew :app:testDebugUnitTest` — 103 tests pass (0 failures)
- [ ] Manual: fresh install → onboarding shows → complete all steps → main screen
- [ ] Manual: relaunch → skips onboarding → main screen directly
- [ ] Manual: back navigation between steps works
- [ ] Manual: login with invalid credentials shows error, retry works
- [ ] Manual: dark mode renders correctly

Refs #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)