### PR TITLE
fix: add R8 dontwarn rules for Tink JSR-305 annotations 🐛

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -10,3 +10,8 @@
 -keep class net.java.dev.jna.** { *; }
 -keep class org.matrix.rustcomponents.sdk.** { *; }
 -keep class uniffi.** { *; }
+
+# Google Tink (transitive via androidx.security:security-crypto / EncryptedSharedPreferences)
+# references JSR-305 annotations that are not present at runtime. Safe to suppress.
+-dontwarn javax.annotation.Nullable
+-dontwarn javax.annotation.concurrent.GuardedBy


### PR DESCRIPTION
## Summary

- Add `dontwarn` rules for `javax.annotation.Nullable` and `javax.annotation.concurrent.GuardedBy` in ProGuard config

R8 minification fails on release builds because Google Tink (transitive dependency via `androidx.security:security-crypto` / `EncryptedSharedPreferences`) references JSR-305 annotations that are compile-time only and not present at runtime. These are safe to suppress.

## Test plan

- [ ] CI `assembleDebug` passes
- [ ] Release build (`assembleRelease`) passes R8 minification — verified when release-please re-runs `build-apk` job after merge

Refs #93
