### PR TITLE
fix: remove bump-patch-for-minor-pre-major from release-please config 🐛

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,6 @@
   "prerelease-type": "alpha",
   "versioning": "prerelease",
   "bump-minor-pre-major": true,
-  "bump-patch-for-minor-pre-major": true,
   "include-v-in-tag": true,
   "include-component-in-tag": false,
   "changelog-sections": [


### PR DESCRIPTION
## Summary

- Remove `"bump-patch-for-minor-pre-major": true` from `release-please-config.json`

This flag causes `feat:` commits to produce **patch** bumps (`0.0.1` → `0.0.2-alpha`) instead of **minor** bumps (`0.0.1` → `0.1.0-alpha`) while the major version is 0. It overrides `bump-minor-pre-major` for features.

### Expected after merge

release-please should create a PR proposing `0.1.0-alpha`:
- `feat:` → minor bump (0.0.1 → 0.1.0) + prerelease suffix (`-alpha`)

## Test plan

- [x] CI passes
- [ ] After merge: release-please PR proposes `0.1.0-alpha` (not `0.0.x`)

Refs #98
