### PR TITLE
fix: correct JNA ProGuard keep rule to com.sun.jna package 🐛

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -7,7 +7,7 @@
 
 # matrix-rust-sdk uses JNA for the native bridge (UniFFI-generated Kotlin bindings).
 # The SDK's consumer-rules.pro is empty, so these must be declared here.
--keep class net.java.dev.jna.** { *; }
+-keep class com.sun.jna.** { *; }
 -keep class org.matrix.rustcomponents.sdk.** { *; }
 -keep class uniffi.** { *; }
 


### PR DESCRIPTION
## Summary

- Fix ProGuard keep rule from `net.java.dev.jna.**` (Maven group ID) to `com.sun.jna.**` (Java package)
- R8 was obfuscating `com.sun.jna.Pointer.peer` which matrix-rust-sdk UniFFI bindings need at runtime
- One-line change in `proguard-rules.pro`

## How this was found

The defensive logging from #107 caught the error and displayed it in the onboarding UI: `Can't obtain peer field ID for class com.sun.jna.Pointer`

## Test plan

- [x] CI passes
- [ ] Release APK: deck-chat can log in to `matrix.akeyra.klazomenai.dev` without crashing

Closes #118
