### PR TITLE
fix: add dontwarn for JNA java.awt references missing on Android 🐛

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -11,6 +11,12 @@
 -keep class org.matrix.rustcomponents.sdk.** { *; }
 -keep class uniffi.** { *; }
 
+# JNA references java.awt classes (Native$AWT) that do not exist on Android.
+# These code paths are never reached on Android — safe to suppress.
+-dontwarn java.awt.GraphicsEnvironment
+-dontwarn java.awt.HeadlessException
+-dontwarn java.awt.Window
+
 # Google Tink (transitive via androidx.security:security-crypto / EncryptedSharedPreferences)
 # references JSR-305 annotations that are not present at runtime. Safe to suppress.
 -dontwarn javax.annotation.Nullable


### PR DESCRIPTION
## Summary

- Add `-dontwarn` rules for `java.awt.GraphicsEnvironment`, `java.awt.HeadlessException`, `java.awt.Window`
- JNA's `Native$AWT` class references these desktop-only classes that do not exist on Android
- The keep rule from #118 correctly targets `com.sun.jna.**` but causes R8 to traverse into these missing references
- No APK was produced for `v0.1.0-alpha.2` due to this build failure

## Test plan

- [ ] CI passes (R8 minification succeeds)
- [ ] Release-please produces a working signed APK
- [ ] APK installs and launches on device
- [ ] Onboarding login reaches the homeserver (verifies both #118 and #122 together)

Closes #122
