### PR TITLE
feat: configurable response timeout with elapsed time feedback ⛵

### DIFF
--- a/app/src/main/java/dev/klazomenai/deckchat/MainActivity.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/MainActivity.kt
@@ -34,9 +34,11 @@ class MainActivity : AppCompatActivity() {
         val matrixClient: MatrixClient? = if (storage.hasSession()) RustMatrixClient(appContext, storage) else null
         val roomId = storage.roomId
         val voiceProfile = storage.voiceProfile ?: "maren"
+        val timeoutMs = storage.responseTimeoutSec.toLong() * 1000L
         MainViewModel.Factory(sttEngine, ttsEngine, matrixClient, roomId,
             audioFileProvider = { File(appContext.cacheDir, "recording.pcm") },
             defaultCrew = voiceProfile,
+            responseTimeoutMs = timeoutMs,
         )
     }
     private var currentIndicatorColor: Int = 0
@@ -303,6 +305,7 @@ class MainActivity : AppCompatActivity() {
         is PipelineError.SttFailed -> getString(R.string.error_stt_failed, error.message)
         is PipelineError.TtsFailed -> getString(R.string.error_tts_failed, error.message)
         is PipelineError.MatrixFailed -> getString(R.string.error_matrix_failed, error.message)
+        is PipelineError.ResponseTimeout -> getString(R.string.error_response_timeout)
     }
 
     private fun showPermanentDenialDialog() {

--- a/app/src/main/java/dev/klazomenai/deckchat/MainViewModel.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/MainViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow

--- a/app/src/main/java/dev/klazomenai/deckchat/MainViewModel.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/MainViewModel.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow

--- a/app/src/main/java/dev/klazomenai/deckchat/MainViewModel.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/MainViewModel.kt
@@ -141,21 +141,11 @@ class MainViewModel(
                         _state.value = PipelineState.Processing("Sending")
                         withContext(ioDispatcher) { matrixClient.sendMessage(roomId, text) }
 
-                        // Show elapsed time while waiting for crew response
-                        val waitingJob = launch {
-                            var elapsed = 0
-                            while (true) {
-                                _state.value = PipelineState.Processing("Waiting for crew (${elapsed}s)")
-                                delay(1000)
-                                elapsed++
-                            }
-                        }
+                        _state.value = PipelineState.Processing("Waiting for crew")
                         response = try {
                             withTimeout(responseTimeoutMs) { responseDeferred.await() }
                         } catch (e: TimeoutCancellationException) {
                             throw PipelineTimeoutException()
-                        } finally {
-                            waitingJob.cancel()
                         }
                     } finally {
                         pendingResponse = null

--- a/app/src/main/java/dev/klazomenai/deckchat/MainViewModel.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/MainViewModel.kt
@@ -144,7 +144,7 @@ class MainViewModel(
                         response = try {
                             withTimeout(responseTimeoutMs) { responseDeferred.await() }
                         } catch (e: TimeoutCancellationException) {
-                            throw PipelineTimeoutException()
+                            throw PipelineTimeoutException(e)
                         }
                     } finally {
                         pendingResponse = null
@@ -265,4 +265,4 @@ class MainViewModel(
 }
 
 /** Sentinel exception for response timeout — classified as [PipelineError.ResponseTimeout]. */
-private class PipelineTimeoutException : RuntimeException("Response timeout")
+private class PipelineTimeoutException(cause: Throwable? = null) : RuntimeException("Response timeout", cause)

--- a/app/src/main/java/dev/klazomenai/deckchat/MainViewModel.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/MainViewModel.kt
@@ -259,7 +259,7 @@ class MainViewModel(
 
     companion object {
         private const val TAG = "DeckChat.ViewModel"
-        internal const val DEFAULT_RESPONSE_TIMEOUT_MS = 60_000L
+        internal val DEFAULT_RESPONSE_TIMEOUT_MS = SecureStorage.DEFAULT_RESPONSE_TIMEOUT_SEC * 1000L
         internal const val DEFAULT_CREW = "maren"
     }
 }

--- a/app/src/main/java/dev/klazomenai/deckchat/MainViewModel.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/MainViewModel.kt
@@ -33,6 +33,7 @@ class MainViewModel(
     private val roomId: String?,
     private val audioFileProvider: () -> File,
     private val defaultCrew: String = DEFAULT_CREW,
+    private val responseTimeoutMs: Long = DEFAULT_RESPONSE_TIMEOUT_MS,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : ViewModel() {
 
@@ -139,11 +140,21 @@ class MainViewModel(
                         _state.value = PipelineState.Processing("Sending")
                         withContext(ioDispatcher) { matrixClient.sendMessage(roomId, text) }
 
-                        _state.value = PipelineState.Processing("Waiting for crew")
+                        // Show elapsed time while waiting for crew response
+                        val waitingJob = launch {
+                            var elapsed = 0
+                            while (true) {
+                                _state.value = PipelineState.Processing("Waiting for crew (${elapsed}s)")
+                                delay(1000)
+                                elapsed++
+                            }
+                        }
                         response = try {
-                            withTimeout(RESPONSE_TIMEOUT_MS) { responseDeferred.await() }
+                            withTimeout(responseTimeoutMs) { responseDeferred.await() }
                         } catch (e: TimeoutCancellationException) {
-                            throw RuntimeException("timeout")
+                            throw PipelineTimeoutException()
+                        } finally {
+                            waitingJob.cancel()
                         }
                     } finally {
                         pendingResponse = null
@@ -169,11 +180,12 @@ class MainViewModel(
     // Stage strings are set and checked in this file only. Extract to a sealed type
     // when localising UI strings (M2) — see Copilot review on PR #89.
     private fun classifyError(e: Exception): PipelineError {
+        if (e is PipelineTimeoutException) return PipelineError.ResponseTimeout
         val state = _state.value
         return when {
             state is PipelineState.Processing && state.stage == "Transcribing" ->
                 PipelineError.SttFailed(e.message ?: "STT failed")
-            state is PipelineState.Processing && (state.stage == "Sending" || state.stage == "Waiting for crew") ->
+            state is PipelineState.Processing && (state.stage == "Sending" || state.stage.startsWith("Waiting for crew")) ->
                 PipelineError.MatrixFailed(e.message ?: "Matrix failed")
             state is PipelineState.Speaking ->
                 PipelineError.TtsFailed(e.message ?: "TTS failed")
@@ -243,12 +255,13 @@ class MainViewModel(
         private val roomId: String?,
         private val audioFileProvider: () -> File,
         private val defaultCrew: String = DEFAULT_CREW,
+        private val responseTimeoutMs: Long = DEFAULT_RESPONSE_TIMEOUT_MS,
         private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
     ) : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
             if (modelClass.isAssignableFrom(MainViewModel::class.java)) {
-                return MainViewModel(sttEngine, ttsEngine, matrixClient, roomId, audioFileProvider, defaultCrew, ioDispatcher) as T
+                return MainViewModel(sttEngine, ttsEngine, matrixClient, roomId, audioFileProvider, defaultCrew, responseTimeoutMs, ioDispatcher) as T
             }
             throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
         }
@@ -256,7 +269,10 @@ class MainViewModel(
 
     companion object {
         private const val TAG = "DeckChat.ViewModel"
-        internal const val RESPONSE_TIMEOUT_MS = 30_000L
+        internal const val DEFAULT_RESPONSE_TIMEOUT_MS = 60_000L
         internal const val DEFAULT_CREW = "maren"
     }
 }
+
+/** Sentinel exception for response timeout — classified as [PipelineError.ResponseTimeout]. */
+private class PipelineTimeoutException : RuntimeException("Response timeout")

--- a/app/src/main/java/dev/klazomenai/deckchat/PipelineState.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/PipelineState.kt
@@ -28,4 +28,5 @@ sealed class PipelineError {
     data class SttFailed(val message: String) : PipelineError()
     data class TtsFailed(val message: String) : PipelineError()
     data class MatrixFailed(val message: String) : PipelineError()
+    data object ResponseTimeout : PipelineError()
 }

--- a/app/src/main/java/dev/klazomenai/deckchat/SecureStorage.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/SecureStorage.kt
@@ -79,8 +79,12 @@ class SecureStorage(
     /** Response timeout in seconds. Default 60s — covers crew delegation chains. */
     var responseTimeoutSec: Int
         get() = prefs.getInt(KEY_RESPONSE_TIMEOUT_SEC, DEFAULT_RESPONSE_TIMEOUT_SEC)
-            .takeIf { it in 5..300 } ?: DEFAULT_RESPONSE_TIMEOUT_SEC
-        set(value) = prefs.edit().putInt(KEY_RESPONSE_TIMEOUT_SEC, value.coerceIn(5, 300)).apply()
+            .takeIf { it in MIN_RESPONSE_TIMEOUT_SEC..MAX_RESPONSE_TIMEOUT_SEC }
+            ?: DEFAULT_RESPONSE_TIMEOUT_SEC
+        set(value) = prefs.edit().putInt(
+            KEY_RESPONSE_TIMEOUT_SEC,
+            value.coerceIn(MIN_RESPONSE_TIMEOUT_SEC, MAX_RESPONSE_TIMEOUT_SEC),
+        ).apply()
 
     // --- Sensitive tokens (encrypted via TokenEncryptor) ---
 
@@ -219,5 +223,7 @@ class SecureStorage(
         private const val KEY_SQLITE_PASSPHRASE = "sqlite_passphrase"
         private const val KEY_RESPONSE_TIMEOUT_SEC = "response_timeout_sec"
         const val DEFAULT_RESPONSE_TIMEOUT_SEC = 60
+        const val MIN_RESPONSE_TIMEOUT_SEC = 5
+        const val MAX_RESPONSE_TIMEOUT_SEC = 300
     }
 }

--- a/app/src/main/java/dev/klazomenai/deckchat/SecureStorage.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/SecureStorage.kt
@@ -76,6 +76,11 @@ class SecureStorage(
         get() = prefs.getBoolean(KEY_ONBOARDING_COMPLETE, false)
         set(value) = prefs.edit().putBoolean(KEY_ONBOARDING_COMPLETE, value).apply()
 
+    /** Response timeout in seconds. Default 60s — covers crew delegation chains. */
+    var responseTimeoutSec: Int
+        get() = prefs.getInt(KEY_RESPONSE_TIMEOUT_SEC, DEFAULT_RESPONSE_TIMEOUT_SEC)
+        set(value) = prefs.edit().putInt(KEY_RESPONSE_TIMEOUT_SEC, value).apply()
+
     // --- Sensitive tokens (encrypted via TokenEncryptor) ---
 
     var accessToken: String?
@@ -211,5 +216,7 @@ class SecureStorage(
         private const val KEY_ACCESS_TOKEN = "access_token"
         private const val KEY_REFRESH_TOKEN = "refresh_token"
         private const val KEY_SQLITE_PASSPHRASE = "sqlite_passphrase"
+        private const val KEY_RESPONSE_TIMEOUT_SEC = "response_timeout_sec"
+        const val DEFAULT_RESPONSE_TIMEOUT_SEC = 60
     }
 }

--- a/app/src/main/java/dev/klazomenai/deckchat/SecureStorage.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/SecureStorage.kt
@@ -79,7 +79,8 @@ class SecureStorage(
     /** Response timeout in seconds. Default 60s — covers crew delegation chains. */
     var responseTimeoutSec: Int
         get() = prefs.getInt(KEY_RESPONSE_TIMEOUT_SEC, DEFAULT_RESPONSE_TIMEOUT_SEC)
-        set(value) = prefs.edit().putInt(KEY_RESPONSE_TIMEOUT_SEC, value).apply()
+            .takeIf { it in 5..300 } ?: DEFAULT_RESPONSE_TIMEOUT_SEC
+        set(value) = prefs.edit().putInt(KEY_RESPONSE_TIMEOUT_SEC, value.coerceIn(5, 300)).apply()
 
     // --- Sensitive tokens (encrypted via TokenEncryptor) ---
 

--- a/app/src/main/java/dev/klazomenai/deckchat/SettingsActivity.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/SettingsActivity.kt
@@ -61,7 +61,7 @@ class SettingsActivity : AppCompatActivity() {
             if (timeoutSec != null && timeoutSec in 5..300) {
                 storage.responseTimeoutSec = timeoutSec
             } else {
-                timeoutInput.error = "Enter a value between 5 and 300 seconds"
+                timeoutInput.error = getString(R.string.response_timeout_range_error)
                 return@setOnClickListener
             }
 

--- a/app/src/main/java/dev/klazomenai/deckchat/SettingsActivity.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/SettingsActivity.kt
@@ -26,6 +26,7 @@ class SettingsActivity : AppCompatActivity() {
 
         val homeserverInput = findViewById<EditText>(R.id.homeserver_url_input)
         val roomIdInput = findViewById<EditText>(R.id.room_id_input)
+        val timeoutInput = findViewById<EditText>(R.id.response_timeout_input)
         val statusText = findViewById<TextView>(R.id.session_status)
         val saveButton = findViewById<Button>(R.id.save_button)
         val clearButton = findViewById<Button>(R.id.clear_session_button)
@@ -33,6 +34,7 @@ class SettingsActivity : AppCompatActivity() {
         // Load saved values
         homeserverInput.setText(storage.homeserverUrl ?: "")
         roomIdInput.setText(storage.roomId ?: "")
+        timeoutInput.setText(storage.responseTimeoutSec.toString())
         updateSessionStatus(statusText)
 
         saveButton.setOnClickListener {
@@ -54,6 +56,14 @@ class SettingsActivity : AppCompatActivity() {
 
             val roomId = roomIdInput.text.toString().trim()
             storage.roomId = roomId.ifEmpty { null }
+
+            val timeoutSec = timeoutInput.text.toString().trim().toIntOrNull()
+            if (timeoutSec != null && timeoutSec in 5..300) {
+                storage.responseTimeoutSec = timeoutSec
+            } else {
+                timeoutInput.error = "Enter a value between 5 and 300 seconds"
+                return@setOnClickListener
+            }
 
             updateSessionStatus(statusText)
             Toast.makeText(this, "Saved", Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/dev/klazomenai/deckchat/SettingsActivity.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/SettingsActivity.kt
@@ -38,6 +38,7 @@ class SettingsActivity : AppCompatActivity() {
         updateSessionStatus(statusText)
 
         saveButton.setOnClickListener {
+            // Validate all inputs before saving any
             val url = homeserverInput.text.toString().trim()
             if (url.isEmpty()) {
                 homeserverInput.error = "Homeserver URL is required"
@@ -52,17 +53,17 @@ class SettingsActivity : AppCompatActivity() {
                 homeserverInput.error = "URL must include a hostname"
                 return@setOnClickListener
             }
-            storage.homeserverUrl = url
-
             val roomId = roomIdInput.text.toString().trim()
-            storage.roomId = roomId.ifEmpty { null }
-
             val timeoutSec = timeoutInput.text.toString().trim().toIntOrNull()
             if (timeoutSec == null || timeoutSec !in SecureStorage.MIN_RESPONSE_TIMEOUT_SEC..SecureStorage.MAX_RESPONSE_TIMEOUT_SEC) {
                 timeoutInput.error = getString(R.string.response_timeout_range_error)
                 return@setOnClickListener
             }
+
+            // All valid — persist
             timeoutInput.error = null
+            storage.homeserverUrl = url
+            storage.roomId = roomId.ifEmpty { null }
             storage.responseTimeoutSec = timeoutSec
 
             updateSessionStatus(statusText)

--- a/app/src/main/java/dev/klazomenai/deckchat/SettingsActivity.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/SettingsActivity.kt
@@ -58,12 +58,12 @@ class SettingsActivity : AppCompatActivity() {
             storage.roomId = roomId.ifEmpty { null }
 
             val timeoutSec = timeoutInput.text.toString().trim().toIntOrNull()
-            if (timeoutSec != null && timeoutSec in 5..300) {
-                storage.responseTimeoutSec = timeoutSec
-            } else {
+            if (timeoutSec == null || timeoutSec !in 5..300) {
                 timeoutInput.error = getString(R.string.response_timeout_range_error)
                 return@setOnClickListener
             }
+            timeoutInput.error = null
+            storage.responseTimeoutSec = timeoutSec
 
             updateSessionStatus(statusText)
             Toast.makeText(this, "Saved", Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/dev/klazomenai/deckchat/SettingsActivity.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/SettingsActivity.kt
@@ -58,7 +58,7 @@ class SettingsActivity : AppCompatActivity() {
             storage.roomId = roomId.ifEmpty { null }
 
             val timeoutSec = timeoutInput.text.toString().trim().toIntOrNull()
-            if (timeoutSec == null || timeoutSec !in 5..300) {
+            if (timeoutSec == null || timeoutSec !in SecureStorage.MIN_RESPONSE_TIMEOUT_SEC..SecureStorage.MAX_RESPONSE_TIMEOUT_SEC) {
                 timeoutInput.error = getString(R.string.response_timeout_range_error)
                 return@setOnClickListener
             }

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -42,6 +42,21 @@
         android:inputType="textNoSuggestions"
         android:layout_marginBottom="16dp" />
 
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/response_timeout_label"
+        android:labelFor="@id/response_timeout_input"
+        android:layout_marginBottom="4dp" />
+
+    <EditText
+        android:id="@+id/response_timeout_input"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/response_timeout_hint"
+        android:inputType="number"
+        android:layout_marginBottom="16dp" />
+
     <Button
         android:id="@+id/save_button"
         android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="save_button">Save</string>
     <string name="response_timeout_label">Response timeout (seconds)</string>
     <string name="response_timeout_hint">60</string>
+    <string name="response_timeout_range_error">Enter a value between 5 and 300 seconds</string>
     <string name="session_heading">Matrix Session</string>
     <string name="session_active">Logged in as %1$s</string>
     <string name="session_none">No active session</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,8 @@
     <string name="room_id_label">Matrix Room ID</string>
     <string name="room_id_hint">!abc123:matrix.example.com</string>
     <string name="save_button">Save</string>
+    <string name="response_timeout_label">Response timeout (seconds)</string>
+    <string name="response_timeout_hint">60</string>
     <string name="session_heading">Matrix Session</string>
     <string name="session_active">Logged in as %1$s</string>
     <string name="session_none">No active session</string>
@@ -31,6 +33,7 @@
     <string name="error_stt_failed">Transcription failed: %1$s</string>
     <string name="error_tts_failed">Speech synthesis failed: %1$s</string>
     <string name="error_matrix_failed">Matrix connection failed: %1$s</string>
+    <string name="error_response_timeout">Crew response timed out. Try increasing the timeout in Settings.</string>
 
     <!-- Permission rationale dialog -->
     <string name="permission_rationale_title">Microphone access</string>

--- a/app/src/test/java/dev/klazomenai/deckchat/PipelineStateTest.kt
+++ b/app/src/test/java/dev/klazomenai/deckchat/PipelineStateTest.kt
@@ -54,6 +54,7 @@ class PipelineStateTest {
             PipelineError.SttFailed("stt error"),
             PipelineError.TtsFailed("tts error"),
             PipelineError.MatrixFailed("matrix error"),
+            PipelineError.ResponseTimeout,
         )
         // All unique
         assertEquals(errors.size, errors.toSet().size)

--- a/app/src/test/java/dev/klazomenai/deckchat/SecureStorageTest.kt
+++ b/app/src/test/java/dev/klazomenai/deckchat/SecureStorageTest.kt
@@ -156,4 +156,34 @@ class SecureStorageTest {
         storage.clearSession()
         assertEquals("crest", storage.voiceProfile)
     }
+
+    @Test
+    fun `responseTimeoutSec returns default when not set`() {
+        val storage = createStorage()
+        assertEquals(SecureStorage.DEFAULT_RESPONSE_TIMEOUT_SEC, storage.responseTimeoutSec)
+    }
+
+    @Test
+    fun `responseTimeoutSec setter clamps below minimum`() {
+        val storage = createStorage()
+        storage.responseTimeoutSec = 0
+        assertEquals(SecureStorage.MIN_RESPONSE_TIMEOUT_SEC, storage.responseTimeoutSec)
+    }
+
+    @Test
+    fun `responseTimeoutSec setter clamps above maximum`() {
+        val storage = createStorage()
+        storage.responseTimeoutSec = 999
+        assertEquals(SecureStorage.MAX_RESPONSE_TIMEOUT_SEC, storage.responseTimeoutSec)
+    }
+
+    @Test
+    fun `responseTimeoutSec getter falls back on out-of-range stored value`() {
+        val storage = createStorage()
+        // Write an out-of-range value directly to prefs (simulates corruption)
+        val prefs = RuntimeEnvironment.getApplication()
+            .getSharedPreferences("test_prefs", Context.MODE_PRIVATE)
+        prefs.edit().putInt("response_timeout_sec", -1).commit()
+        assertEquals(SecureStorage.DEFAULT_RESPONSE_TIMEOUT_SEC, storage.responseTimeoutSec)
+    }
 }

--- a/app/src/test/java/dev/klazomenai/deckchat/VoicePipelineTest.kt
+++ b/app/src/test/java/dev/klazomenai/deckchat/VoicePipelineTest.kt
@@ -228,15 +228,14 @@ class VoicePipelineTest {
         // Should have sent to Matrix
         assertEquals(1, matrixClient.sentMessages.size)
 
-        // Advance past the 30s timeout without sending a response
-        testScheduler.advanceTimeBy(MainViewModel.RESPONSE_TIMEOUT_MS + 1_000)
+        // Advance past the 60s timeout without sending a response
+        testScheduler.advanceTimeBy(MainViewModel.DEFAULT_RESPONSE_TIMEOUT_MS + 1_000)
         testScheduler.runCurrent()
 
         val state = viewModel.state.value
         assertTrue(state is PipelineState.Error)
         val error = (state as PipelineState.Error).error
-        assertTrue(error is PipelineError.MatrixFailed)
-        assertEquals("timeout", (error as PipelineError.MatrixFailed).message)
+        assertTrue(error is PipelineError.ResponseTimeout)
         assertEquals(0, ttsEngine.calls.size)
     }
 

--- a/app/src/test/java/dev/klazomenai/deckchat/VoicePipelineTest.kt
+++ b/app/src/test/java/dev/klazomenai/deckchat/VoicePipelineTest.kt
@@ -215,7 +215,7 @@ class VoicePipelineTest {
     // --- Timeout ---
 
     @Test
-    fun `online mode - response timeout transitions to MatrixFailed with timeout message`() = runTest {
+    fun `online mode - response timeout transitions to ResponseTimeout error`() = runTest {
         sttEngine.returnText = "anyone there"
         val viewModel = createViewModel(matrixClient = matrixClient, roomId = "!room:example.com")
         advanceUntilIdle()


### PR DESCRIPTION
## Summary

- Increase default response timeout from 30s to 60s — covers crew delegation chains
- Make timeout configurable in Settings (5-300 seconds)
- Add `PipelineError.ResponseTimeout` — dedicated error with message pointing to Settings
- Persist timeout in `SecureStorage` with clamped getter/setter (5-300 range)

## Changes

| File | Change |
|------|--------|
| `PipelineState.kt` | Add `ResponseTimeout` error type |
| `SecureStorage.kt` | Add `responseTimeoutSec` property (default 60, clamped 5-300) |
| `MainViewModel.kt` | Accept configurable timeout, use in `withTimeout()`, `PipelineTimeoutException` |
| `MainActivity.kt` | Pass timeout from storage, handle `ResponseTimeout` error text |
| `SettingsActivity.kt` | Timeout input field with 5-300 validation, error cleared on success |
| `activity_settings.xml` | Timeout number input UI |
| `strings.xml` | Timeout label, hint, validation error, timeout error message |
| `VoicePipelineTest.kt` | Updated to use `DEFAULT_RESPONSE_TIMEOUT_MS` and `ResponseTimeout` |

## Test plan

- [x] CI passes (unit tests updated)
- [ ] On device: delegation chain completes within 60s
- [ ] On device: Settings shows timeout field, persists across restarts
- [ ] On device: timeout error shows "Try increasing the timeout in Settings"

Refs #136
