### PR TITLE
chore: compute versionCode from versionName at build time ⚙️

### DIFF
--- a/.github/workflows/RELEASE-PLEASE.md
+++ b/.github/workflows/RELEASE-PLEASE.md
@@ -75,7 +75,7 @@ versionCode than any prerelease of the same version.
 Prerelease versions must use a lowercase alphabetic label in the form `-label` or
 `-label.N`; only the trailing number affects `versionCode`, and a bare label is treated
 as prerelease 0. The build fails if any slot exceeds its range
-(minor/patch/prerelease must be 0–99).
+(minor/patch must be 0–99; prerelease must be 0–98, since 99 is reserved for stable).
 
 No per-release commits are needed — release-please bumps `versionName` via the
 `x-release-please-version` marker, and `versionCode` follows automatically.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,7 +19,8 @@ plugins {
  * only the optional trailing number affects the prerelease slot.
  *
  * Stable releases use pre=99 so they always beat prereleases of the same version.
- * Supports up to 99 prereleases per patch, 99 patches per minor, 99 minors per major.
+ * Supports up to 98 prereleases per patch (99 reserved for stable), 99 patches per minor,
+ * 99 minors per major.
  * Build fails if any slot exceeds its range.
  */
 fun computeVersionCode(version: String): Int {
@@ -35,7 +36,7 @@ fun computeVersionCode(version: String): Int {
     }
     require(minor in 0L..99L) { "minor $minor exceeds 0..99 in '$version'" }
     require(patch in 0L..99L) { "patch $patch exceeds 0..99 in '$version'" }
-    require(pre in 0L..99L) { "prerelease $pre exceeds 0..99 in '$version'" }
+    require(pre in 0L..98L) { "prerelease $pre exceeds 0..98 in '$version' (99 is reserved for stable)" }
     val code = major * 1_000_000L + minor * 10_000L + patch * 100L + pre
     require(code <= Int.MAX_VALUE.toLong()) { "versionCode $code exceeds Int.MAX_VALUE for '$version'" }
     return code.toInt()


### PR DESCRIPTION
## Summary

- Compute `versionCode` from `versionName` at build time using a deterministic formula
- Formula: `major * 1_000_000 + minor * 10_000 + patch * 100 + prerelease`
- Stable releases use `pre=99` so they always beat prereleases of the same version
- Any prerelease label supported (alpha, beta, rc, etc.) — only the trailing number matters
- Build fails if any slot exceeds its 0–99 range
- No per-release commits needed — release-please bumps `versionName`, `versionCode` follows automatically

## Examples

| versionName | versionCode |
|-------------|-------------|
| `0.1.0-alpha` | `10000` |
| `0.1.0-alpha.6` | `10006` |
| `0.1.0` | `10099` |
| `0.3.0-beta.2` | `30002` |
| `0.3.0` | `30099` |
| `1.0.0` | `1000099` |

## Verified

```
aapt dump badging app-debug.apk | grep versionCode
→ versionCode='10006' versionName='0.1.0-alpha.6'
```

## Test plan

- [x] `./gradlew assembleDebug` builds successfully
- [x] APK contains `versionCode=10006` for `0.1.0-alpha.6`
- [x] CI passes

Closes #121
