### PR TITLE
fix(test): wrap tearDown in try/finally to guarantee Dispatchers.resetMain() 🐛

### DIFF
--- a/app/src/test/java/dev/klazomenai/deckchat/MainViewModelTest.kt
+++ b/app/src/test/java/dev/klazomenai/deckchat/MainViewModelTest.kt
@@ -29,10 +29,13 @@ class MainViewModelTest {
 
     @After
     fun tearDown() {
-        viewModels.forEach { it.releaseResources() }
-        viewModels.clear()
-        Dispatchers.resetMain()
-        audioFile.delete()
+        try {
+            viewModels.forEach { it.releaseResources() }
+            viewModels.clear()
+        } finally {
+            Dispatchers.resetMain()
+            audioFile.delete()
+        }
     }
 
     private fun createViewModel(

--- a/app/src/test/java/dev/klazomenai/deckchat/MainViewModelTest.kt
+++ b/app/src/test/java/dev/klazomenai/deckchat/MainViewModelTest.kt
@@ -34,7 +34,9 @@ class MainViewModelTest {
             viewModels.clear()
         } finally {
             Dispatchers.resetMain()
-            audioFile.delete()
+            if (::audioFile.isInitialized) {
+                audioFile.delete()
+            }
         }
     }
 

--- a/app/src/test/java/dev/klazomenai/deckchat/VoicePipelineTest.kt
+++ b/app/src/test/java/dev/klazomenai/deckchat/VoicePipelineTest.kt
@@ -47,7 +47,9 @@ class VoicePipelineTest {
             viewModels.clear()
         } finally {
             Dispatchers.resetMain()
-            audioFile.delete()
+            if (::audioFile.isInitialized) {
+                audioFile.delete()
+            }
         }
     }
 

--- a/app/src/test/java/dev/klazomenai/deckchat/VoicePipelineTest.kt
+++ b/app/src/test/java/dev/klazomenai/deckchat/VoicePipelineTest.kt
@@ -42,10 +42,13 @@ class VoicePipelineTest {
 
     @After
     fun tearDown() {
-        viewModels.forEach { it.releaseResources() }
-        viewModels.clear()
-        Dispatchers.resetMain()
-        audioFile.delete()
+        try {
+            viewModels.forEach { it.releaseResources() }
+            viewModels.clear()
+        } finally {
+            Dispatchers.resetMain()
+            audioFile.delete()
+        }
     }
 
     private fun createViewModel(


### PR DESCRIPTION
## Summary

Wrap `@After tearDown()` in `try/finally` so `Dispatchers.resetMain()` and `audioFile.delete()` are guaranteed to run even if `releaseResources()` throws.

Refs #150

## Why

If `releaseResources()` throws (e.g. `client.stop()` fails), `Dispatchers.resetMain()` never executes. The leaked `StandardTestDispatcher` set as `Dispatchers.Main` corrupts every subsequent test class in the same JVM process — non-deterministic cross-test failures that are extremely hard to trace.

Identified by Copilot during klazomenai/dotfiles#80 review (android skill coroutine testing patterns). The skill now teaches the correct pattern; this PR closes the loop by applying it to the tests it was derived from.

## Changes

- `app/src/test/java/dev/klazomenai/deckchat/MainViewModelTest.kt` — `tearDown()` wrapped in `try/finally`
- `app/src/test/java/dev/klazomenai/deckchat/VoicePipelineTest.kt` — identical edit

Both `Dispatchers.resetMain()` AND `audioFile.delete()` moved into `finally` — temp files should also be guaranteed cleanup.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest --tests MainViewModelTest --tests VoicePipelineTest` — BUILD SUCCESSFUL
- [x] CI passes on PR
