### PR TITLE
fix: queue crew messages and speak final response for delegation chains 🐛

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -93,6 +93,10 @@ android {
         }
     }
 
+    testOptions {
+        unitTests.isReturnDefaultValues = true
+    }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17

--- a/app/src/main/java/dev/klazomenai/deckchat/MainViewModel.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/MainViewModel.kt
@@ -52,6 +52,8 @@ class MainViewModel(
 
     @VisibleForTesting
     internal val crewMessages = Channel<CrewMessage>(Channel.UNLIMITED)
+    @Volatile
+    private var awaitingResponse = false
 
     init {
         viewModelScope.launch {
@@ -103,7 +105,7 @@ class MainViewModel(
 
                     Log.d(TAG, "Session restored, starting sync")
                     matrixClient.startSync { crewMessage ->
-                        crewMessages.trySend(crewMessage)
+                        if (awaitingResponse) crewMessages.trySend(crewMessage)
                     }
 
                     Log.d(TAG, "Sync started, listening to room")
@@ -142,17 +144,17 @@ class MainViewModel(
 
                 if (matrixClient != null && roomId != null) {
                     // Online mode: send to Matrix, await crew response, speak it
-                    // Drain stale messages from previous interactions
-                    while (crewMessages.tryReceive().isSuccess) { /* drain */ }
-
                     _state.value = PipelineState.Processing("Sending")
                     withContext(ioDispatcher) { matrixClient.sendMessage(roomId, text) }
 
                     _state.value = PipelineState.Processing("Waiting for crew")
+                    awaitingResponse = true
                     val response: CrewMessage = try {
                         withTimeout(responseTimeoutMs) { awaitFinalResponse() }
                     } catch (e: TimeoutCancellationException) {
                         throw PipelineTimeoutException(e)
+                    } finally {
+                        awaitingResponse = false
                     }
 
                     _lastCrewResponse.value = response

--- a/app/src/main/java/dev/klazomenai/deckchat/MainViewModel.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/MainViewModel.kt
@@ -144,15 +144,18 @@ class MainViewModel(
 
                 if (matrixClient != null && roomId != null) {
                     // Online mode: send to Matrix, await crew response, speak it
-                    _state.value = PipelineState.Processing("Sending")
-                    withContext(ioDispatcher) { matrixClient.sendMessage(roomId, text) }
-
-                    _state.value = PipelineState.Processing("Waiting for crew")
                     awaitingResponse = true
-                    val response: CrewMessage = try {
-                        withTimeout(responseTimeoutMs) { awaitFinalResponse() }
-                    } catch (e: TimeoutCancellationException) {
-                        throw PipelineTimeoutException(e)
+                    val response: CrewMessage
+                    try {
+                        _state.value = PipelineState.Processing("Sending")
+                        withContext(ioDispatcher) { matrixClient.sendMessage(roomId, text) }
+
+                        _state.value = PipelineState.Processing("Waiting for crew")
+                        response = try {
+                            withTimeout(responseTimeoutMs) { awaitFinalResponse() }
+                        } catch (e: TimeoutCancellationException) {
+                            throw PipelineTimeoutException(e)
+                        }
                     } finally {
                         awaitingResponse = false
                     }
@@ -180,6 +183,8 @@ class MainViewModel(
      * Handles delegation chains where multiple crew members respond sequentially.
      */
     private suspend fun awaitFinalResponse(): CrewMessage {
+        // Drain any messages buffered between awaitingResponse=true and now
+        while (crewMessages.tryReceive().isSuccess) { /* drain */ }
         var latest = crewMessages.receive() // block until first message
         while (true) {
             val next = withTimeoutOrNull(DELEGATION_SETTLE_MS) {

--- a/app/src/main/java/dev/klazomenai/deckchat/MainViewModel.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/MainViewModel.kt
@@ -144,6 +144,8 @@ class MainViewModel(
 
                 if (matrixClient != null && roomId != null) {
                     // Online mode: send to Matrix, await crew response, speak it
+                    // Drain stale messages before opening the gate
+                    while (crewMessages.tryReceive().isSuccess) { /* drain */ }
                     awaitingResponse = true
                     val response: CrewMessage
                     try {
@@ -183,8 +185,6 @@ class MainViewModel(
      * Handles delegation chains where multiple crew members respond sequentially.
      */
     private suspend fun awaitFinalResponse(): CrewMessage {
-        // Drain any messages buffered between awaitingResponse=true and now
-        while (crewMessages.tryReceive().isSuccess) { /* drain */ }
         var latest = crewMessages.receive() // block until first message
         while (true) {
             val next = withTimeoutOrNull(DELEGATION_SETTLE_MS) {

--- a/app/src/main/java/dev/klazomenai/deckchat/MainViewModel.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/MainViewModel.kt
@@ -5,11 +5,11 @@ import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -17,6 +17,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 import java.io.File
 
 /**
@@ -49,7 +50,8 @@ class MainViewModel(
     private val _lastCrewResponse = MutableStateFlow<CrewMessage?>(null)
     val lastCrewResponse: StateFlow<CrewMessage?> = _lastCrewResponse.asStateFlow()
 
-    private var pendingResponse: CompletableDeferred<CrewMessage>? = null
+    @VisibleForTesting
+    internal val crewMessages = Channel<CrewMessage>(Channel.UNLIMITED)
 
     init {
         viewModelScope.launch {
@@ -101,9 +103,7 @@ class MainViewModel(
 
                     Log.d(TAG, "Session restored, starting sync")
                     matrixClient.startSync { crewMessage ->
-                        viewModelScope.launch {
-                            pendingResponse?.complete(crewMessage)
-                        }
+                        crewMessages.trySend(crewMessage)
                     }
 
                     Log.d(TAG, "Sync started, listening to room")
@@ -142,21 +142,17 @@ class MainViewModel(
 
                 if (matrixClient != null && roomId != null) {
                     // Online mode: send to Matrix, await crew response, speak it
-                    val responseDeferred = CompletableDeferred<CrewMessage>()
-                    pendingResponse = responseDeferred
-                    val response: CrewMessage
-                    try {
-                        _state.value = PipelineState.Processing("Sending")
-                        withContext(ioDispatcher) { matrixClient.sendMessage(roomId, text) }
+                    // Drain stale messages from previous interactions
+                    while (crewMessages.tryReceive().isSuccess) { /* drain */ }
 
-                        _state.value = PipelineState.Processing("Waiting for crew")
-                        response = try {
-                            withTimeout(responseTimeoutMs) { responseDeferred.await() }
-                        } catch (e: TimeoutCancellationException) {
-                            throw PipelineTimeoutException(e)
-                        }
-                    } finally {
-                        pendingResponse = null
+                    _state.value = PipelineState.Processing("Sending")
+                    withContext(ioDispatcher) { matrixClient.sendMessage(roomId, text) }
+
+                    _state.value = PipelineState.Processing("Waiting for crew")
+                    val response: CrewMessage = try {
+                        withTimeout(responseTimeoutMs) { awaitFinalResponse() }
+                    } catch (e: TimeoutCancellationException) {
+                        throw PipelineTimeoutException(e)
                     }
 
                     _lastCrewResponse.value = response
@@ -175,6 +171,22 @@ class MainViewModel(
                 _state.value = PipelineState.Error(classifyError(e))
             }
         }
+    }
+
+    /**
+     * Waits for crew messages, returning the last one after a settling period.
+     * Handles delegation chains where multiple crew members respond sequentially.
+     */
+    private suspend fun awaitFinalResponse(): CrewMessage {
+        var latest = crewMessages.receive() // block until first message
+        while (true) {
+            val next = withTimeoutOrNull(DELEGATION_SETTLE_MS) {
+                crewMessages.receive()
+            }
+            if (next == null) break // no more messages within settle window
+            latest = next
+        }
+        return latest
     }
 
     // Stage strings are set and checked in this file only. Extract to a sealed type
@@ -239,8 +251,7 @@ class MainViewModel(
 
     @VisibleForTesting
     internal fun releaseResources() {
-        pendingResponse?.cancel()
-        pendingResponse = null
+        crewMessages.close()
         sttEngine.close()
         ttsEngine.close()
         matrixClient?.let { client ->
@@ -271,6 +282,7 @@ class MainViewModel(
         private const val TAG = "DeckChat.ViewModel"
         internal val DEFAULT_RESPONSE_TIMEOUT_MS = SecureStorage.DEFAULT_RESPONSE_TIMEOUT_SEC * 1000L
         internal const val DEFAULT_CREW = "maren"
+        internal const val DELEGATION_SETTLE_MS = 5_000L
     }
 }
 

--- a/app/src/main/java/dev/klazomenai/deckchat/SecureStorage.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/SecureStorage.kt
@@ -229,7 +229,7 @@ class SecureStorage(
         private const val KEY_RESPONSE_TIMEOUT_SEC = "response_timeout_sec"
         private const val KEY_DEBUG_MODE = "debug_mode"
         const val DEFAULT_RESPONSE_TIMEOUT_SEC = 60
-        const val MIN_RESPONSE_TIMEOUT_SEC = 5
+        const val MIN_RESPONSE_TIMEOUT_SEC = 15
         const val MAX_RESPONSE_TIMEOUT_SEC = 300
     }
 }

--- a/app/src/main/java/dev/klazomenai/deckchat/SecureStorage.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/SecureStorage.kt
@@ -84,8 +84,7 @@ class SecureStorage(
     /** Response timeout in seconds. Default 60s — covers crew delegation chains. */
     var responseTimeoutSec: Int
         get() = prefs.getInt(KEY_RESPONSE_TIMEOUT_SEC, DEFAULT_RESPONSE_TIMEOUT_SEC)
-            .takeIf { it in MIN_RESPONSE_TIMEOUT_SEC..MAX_RESPONSE_TIMEOUT_SEC }
-            ?: DEFAULT_RESPONSE_TIMEOUT_SEC
+            .coerceIn(MIN_RESPONSE_TIMEOUT_SEC, MAX_RESPONSE_TIMEOUT_SEC)
         set(value) = prefs.edit().putInt(
             KEY_RESPONSE_TIMEOUT_SEC,
             value.coerceIn(MIN_RESPONSE_TIMEOUT_SEC, MAX_RESPONSE_TIMEOUT_SEC),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,7 +9,7 @@
     <string name="save_button">Save</string>
     <string name="response_timeout_label">Response timeout (seconds)</string>
     <string name="response_timeout_hint">60</string>
-    <string name="response_timeout_range_error">Enter a value between 5 and 300 seconds</string>
+    <string name="response_timeout_range_error">Enter a value between 15 and 300 seconds</string>
     <string name="debug_heading">Debug</string>
     <string name="debug_mode_label">Show transcript</string>
     <string name="debug_transcript_you">You: %1$s</string>

--- a/app/src/test/java/dev/klazomenai/deckchat/MainViewModelTest.kt
+++ b/app/src/test/java/dev/klazomenai/deckchat/MainViewModelTest.kt
@@ -324,58 +324,83 @@ class MainViewModelTest {
 
     // --- Delegation settling ---
 
-    @Test
-    fun `single crew message returned after settling`() = runTest {
-        val viewModel = createViewModel(sttResult = "hello")
-        testDispatcher.scheduler.advanceUntilIdle()
-
-        val msg = CrewMessage("maren", "dispatch", "Aye aye", "@bridge:example.com")
-        viewModel.crewMessages.trySend(msg)
-
-        // Settle window: advance past 5s
-        testDispatcher.scheduler.advanceTimeBy(MainViewModel.DELEGATION_SETTLE_MS + 100)
-        testDispatcher.scheduler.runCurrent()
-
-        // Channel should have been consumed — verify via lastCrewResponse if pipeline ran
-        // (Direct channel test: just verify the message is consumable)
-        assertTrue(true) // structural — real integration tested on device
+    private fun createOnlineViewModel(
+        sttResult: String = "hello",
+        matrixClient: MockMatrixClient = MockMatrixClient(),
+        roomId: String = "!room:example.com",
+    ): Pair<MainViewModel, MockMatrixClient> {
+        val tts = MockTtsEngine()
+        val vm = MainViewModel(
+            sttEngine = MockSttEngine(returnText = sttResult),
+            ttsEngine = tts,
+            matrixClient = matrixClient,
+            roomId = roomId,
+            audioFileProvider = { audioFile },
+            ioDispatcher = testDispatcher,
+        ).also { viewModels.add(it) }
+        return vm to matrixClient
     }
 
     @Test
-    fun `delegation chain returns last message`() = runTest {
-        val viewModel = createViewModel(sttResult = "hello")
+    fun `single crew message spoken after settling`() = runTest {
+        val (viewModel, _) = createOnlineViewModel()
+        testDispatcher.scheduler.advanceUntilIdle() // init + sync
+
+        // Trigger pipeline — use runCurrent to advance without blowing through timeout
+        RecordingService.emitEvent(ServiceEvent.RecordingStopped)
+        testDispatcher.scheduler.runCurrent() // process event
+        testDispatcher.scheduler.runCurrent() // process pipeline launch + STT + send
+
+        // Pipeline is now suspended at crewMessages.receive()
+        viewModel.crewMessages.trySend(CrewMessage("maren", "dispatch", "Aye aye", "@bridge:example.com"))
+        testDispatcher.scheduler.runCurrent()
+
+        // Advance past settling window so pipeline completes
+        testDispatcher.scheduler.advanceTimeBy(MainViewModel.DELEGATION_SETTLE_MS + 100)
         testDispatcher.scheduler.advanceUntilIdle()
 
-        val maren = CrewMessage("maren", "dispatch", "Passing to Crest", "@bridge:example.com")
-        val crest = CrewMessage("crest", "dispatch", "Signal received", "@bridge:example.com")
+        assertEquals("Aye aye", viewModel.lastCrewResponse.value?.body)
+        assertEquals("maren", viewModel.lastCrewResponse.value?.crewName)
+    }
 
-        // Simulate: maren responds, then crest 2s later
-        viewModel.crewMessages.trySend(maren)
+    @Test
+    fun `delegation chain speaks last message`() = runTest {
+        val (viewModel, _) = createOnlineViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        RecordingService.emitEvent(ServiceEvent.RecordingStopped)
+        testDispatcher.scheduler.runCurrent()
+        testDispatcher.scheduler.runCurrent()
+
+        // Maren responds first
+        viewModel.crewMessages.trySend(CrewMessage("maren", "dispatch", "Passing to Crest", "@bridge:example.com"))
+        testDispatcher.scheduler.runCurrent()
+
+        // Crest responds 2s later (within settle window)
         testDispatcher.scheduler.advanceTimeBy(2_000)
-        viewModel.crewMessages.trySend(crest)
+        viewModel.crewMessages.trySend(CrewMessage("crest", "dispatch", "Signal received", "@bridge:example.com"))
+        testDispatcher.scheduler.runCurrent()
 
         // Advance past settle window from last message
         testDispatcher.scheduler.advanceTimeBy(MainViewModel.DELEGATION_SETTLE_MS + 100)
-        testDispatcher.scheduler.runCurrent()
+        testDispatcher.scheduler.advanceUntilIdle()
 
-        assertTrue(true) // structural — real integration tested on device
+        assertEquals("Signal received", viewModel.lastCrewResponse.value?.body)
+        assertEquals("crest", viewModel.lastCrewResponse.value?.crewName)
     }
 
     @Test
-    fun `stale messages drained before new pipeline run`() = runTest {
-        val viewModel = createViewModel(sttResult = "hello")
+    fun `messages ignored when not awaiting response`() = runTest {
+        val (viewModel, mock) = createOnlineViewModel()
         testDispatcher.scheduler.advanceUntilIdle()
 
-        // Inject a stale message before pipeline runs
-        val stale = CrewMessage("maren", "dispatch", "Old message", "@bridge:example.com")
-        viewModel.crewMessages.trySend(stale)
+        // Pipeline is idle — not awaiting response.
+        // simulateMessage goes through the callback which checks awaitingResponse.
+        mock.simulateMessage(CrewMessage("maren", "dispatch", "Stale", "@bridge:example.com"))
+        testDispatcher.scheduler.advanceUntilIdle()
 
-        // Pipeline will drain this during runPipeline — verify channel is empty after drain
-        // The drain happens at start of online mode, but we have no matrixClient here
-        // so pipeline takes the local-echo path. Verify channel still has the message.
-        val received = viewModel.crewMessages.tryReceive()
-        assertTrue(received.isSuccess)
-        assertEquals("Old message", received.getOrNull()?.body)
+        // Channel should be empty since awaitingResponse was false
+        assertTrue(viewModel.crewMessages.tryReceive().isFailure)
     }
 
     // --- Voice profile ---

--- a/app/src/test/java/dev/klazomenai/deckchat/MainViewModelTest.kt
+++ b/app/src/test/java/dev/klazomenai/deckchat/MainViewModelTest.kt
@@ -322,6 +322,62 @@ class MainViewModelTest {
         assertNull(viewModel.lastUserText.value)
     }
 
+    // --- Delegation settling ---
+
+    @Test
+    fun `single crew message returned after settling`() = runTest {
+        val viewModel = createViewModel(sttResult = "hello")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val msg = CrewMessage("maren", "dispatch", "Aye aye", "@bridge:example.com")
+        viewModel.crewMessages.trySend(msg)
+
+        // Settle window: advance past 5s
+        testDispatcher.scheduler.advanceTimeBy(MainViewModel.DELEGATION_SETTLE_MS + 100)
+        testDispatcher.scheduler.runCurrent()
+
+        // Channel should have been consumed — verify via lastCrewResponse if pipeline ran
+        // (Direct channel test: just verify the message is consumable)
+        assertTrue(true) // structural — real integration tested on device
+    }
+
+    @Test
+    fun `delegation chain returns last message`() = runTest {
+        val viewModel = createViewModel(sttResult = "hello")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val maren = CrewMessage("maren", "dispatch", "Passing to Crest", "@bridge:example.com")
+        val crest = CrewMessage("crest", "dispatch", "Signal received", "@bridge:example.com")
+
+        // Simulate: maren responds, then crest 2s later
+        viewModel.crewMessages.trySend(maren)
+        testDispatcher.scheduler.advanceTimeBy(2_000)
+        viewModel.crewMessages.trySend(crest)
+
+        // Advance past settle window from last message
+        testDispatcher.scheduler.advanceTimeBy(MainViewModel.DELEGATION_SETTLE_MS + 100)
+        testDispatcher.scheduler.runCurrent()
+
+        assertTrue(true) // structural — real integration tested on device
+    }
+
+    @Test
+    fun `stale messages drained before new pipeline run`() = runTest {
+        val viewModel = createViewModel(sttResult = "hello")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Inject a stale message before pipeline runs
+        val stale = CrewMessage("maren", "dispatch", "Old message", "@bridge:example.com")
+        viewModel.crewMessages.trySend(stale)
+
+        // Pipeline will drain this during runPipeline — verify channel is empty after drain
+        // The drain happens at start of online mode, but we have no matrixClient here
+        // so pipeline takes the local-echo path. Verify channel still has the message.
+        val received = viewModel.crewMessages.tryReceive()
+        assertTrue(received.isSuccess)
+        assertEquals("Old message", received.getOrNull()?.body)
+    }
+
     // --- Voice profile ---
 
     @Test

--- a/app/src/test/java/dev/klazomenai/deckchat/MainViewModelTest.kt
+++ b/app/src/test/java/dev/klazomenai/deckchat/MainViewModelTest.kt
@@ -355,6 +355,9 @@ class MainViewModelTest {
         viewModel.crewMessages.trySend(CrewMessage("maren", "dispatch", "Aye aye", "@bridge:example.com"))
         testDispatcher.scheduler.runCurrent()
 
+        // Response received but settle window not elapsed — should not be spoken yet
+        assertNull(viewModel.lastCrewResponse.value)
+
         // Advance past settling window so pipeline completes
         testDispatcher.scheduler.advanceTimeBy(MainViewModel.DELEGATION_SETTLE_MS + 100)
         testDispatcher.scheduler.advanceUntilIdle()
@@ -376,10 +379,16 @@ class MainViewModelTest {
         viewModel.crewMessages.trySend(CrewMessage("maren", "dispatch", "Passing to Crest", "@bridge:example.com"))
         testDispatcher.scheduler.runCurrent()
 
+        // Maren received but settle window not elapsed — should not be finalized
+        assertNull(viewModel.lastCrewResponse.value)
+
         // Crest responds 2s later (within settle window)
         testDispatcher.scheduler.advanceTimeBy(2_000)
         viewModel.crewMessages.trySend(CrewMessage("crest", "dispatch", "Signal received", "@bridge:example.com"))
         testDispatcher.scheduler.runCurrent()
+
+        // Crest received but settle window restarted — still not finalized
+        assertNull(viewModel.lastCrewResponse.value)
 
         // Advance past settle window from last message
         testDispatcher.scheduler.advanceTimeBy(MainViewModel.DELEGATION_SETTLE_MS + 100)

--- a/app/src/test/java/dev/klazomenai/deckchat/SecureStorageTest.kt
+++ b/app/src/test/java/dev/klazomenai/deckchat/SecureStorageTest.kt
@@ -193,12 +193,12 @@ class SecureStorageTest {
     }
 
     @Test
-    fun `responseTimeoutSec getter falls back on out-of-range stored value`() {
+    fun `responseTimeoutSec getter clamps out-of-range stored value to minimum`() {
         val storage = createStorage()
-        // Write an out-of-range value directly to prefs (simulates corruption)
+        // Write an out-of-range value directly to prefs (simulates corruption or upgrade)
         val prefs = RuntimeEnvironment.getApplication()
             .getSharedPreferences("test_prefs", Context.MODE_PRIVATE)
         prefs.edit().putInt("response_timeout_sec", -1).commit()
-        assertEquals(SecureStorage.DEFAULT_RESPONSE_TIMEOUT_SEC, storage.responseTimeoutSec)
+        assertEquals(SecureStorage.MIN_RESPONSE_TIMEOUT_SEC, storage.responseTimeoutSec)
     }
 }


### PR DESCRIPTION
## Summary

- Replace `CompletableDeferred` with `Channel` to collect all crew messages
- After first message, wait 5s for additional messages (delegation settling)
- Speak the last message received — the final crew response in a delegation chain
- Drain stale messages at pipeline start to prevent cross-interaction leaks

## Problem

When Maren delegates to Crest, the bridge sends two messages:
1. `[maren:dispatch] <Maren's text>`
2. `[crest:dispatch] <Crest's response>`

`CompletableDeferred` completed on message #1, dropping Crest's response entirely.

## How the settling window works

```
User sends message
├── Maren responds at t=8s (no delegation)
│   └── Wait 5s → nothing → speak Maren at t=13s
└── Maren responds at t=8s, Crest responds at t=12s
    └── Receive Maren at t=8, start 5s settle
    └── Receive Crest at t=12, restart 5s settle
    └── Nothing at t=17 → speak Crest at t=17s
```

The 5s settling window adds latency to all responses (direct and delegated).
The response timeout (user-configurable, default 60s) is the outer bound.

## Test plan

- [x] Direct Maren response works (speaks after 5s settle)
- [x] Delegation chain: Maren → Crest — speaks Crest's response
- [x] Timeout fires if bridge unresponsive
- [x] Debug transcript shows final response
- [x] CI passes

Refs #154