### PR TITLE
feat: add pipeline timing display to debug mode ✨

### DIFF
--- a/app/src/main/java/dev/klazomenai/deckchat/MainActivity.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/MainActivity.kt
@@ -142,8 +142,8 @@ class MainActivity : AppCompatActivity() {
     private fun updateTranscript() {
         val userText = viewModel.lastUserText.value
         val crewMsg = viewModel.lastCrewResponse.value
-        val timings = viewModel.lastTimings.value
-        val timingsVisible = debugMode && showTimings && timings != null
+        val t = viewModel.lastTimings.value
+        val timingsVisible = debugMode && showTimings && t != null
 
         if (debugMode && userText != null) {
             debugUserText.text = getString(R.string.debug_transcript_you, userText)
@@ -152,13 +152,14 @@ class MainActivity : AppCompatActivity() {
             debugUserText.visibility = View.GONE
         }
         if (timingsVisible && userText != null) {
-            debugTimingStt.text = getString(R.string.debug_timing_stt, formatDuration(timings!!.sttMs))
+            debugTimingStt.text = getString(R.string.debug_timing_stt, formatDuration(t!!.sttMs))
             debugTimingStt.visibility = View.VISIBLE
         } else {
             debugTimingStt.visibility = View.GONE
         }
-        if (timingsVisible && timings!!.bridgeMs != null) {
-            debugTimingBridge.text = getString(R.string.debug_timing_bridge, formatDuration(timings.bridgeMs))
+        val bridgeMs = t?.bridgeMs
+        if (timingsVisible && bridgeMs != null) {
+            debugTimingBridge.text = getString(R.string.debug_timing_bridge, formatDuration(bridgeMs))
             debugTimingBridge.visibility = View.VISIBLE
         } else {
             debugTimingBridge.visibility = View.GONE
@@ -171,9 +172,9 @@ class MainActivity : AppCompatActivity() {
             debugCrewText.visibility = View.GONE
         }
         if (timingsVisible) {
-            debugTimingTts.text = getString(R.string.debug_timing_tts, formatDuration(timings!!.ttsMs))
+            debugTimingTts.text = getString(R.string.debug_timing_tts, formatDuration(t!!.ttsMs))
             debugTimingTts.visibility = View.VISIBLE
-            debugTimingTotal.text = getString(R.string.debug_timing_total, formatDuration(timings.totalMs))
+            debugTimingTotal.text = getString(R.string.debug_timing_total, formatDuration(t.totalMs))
             debugTimingTotal.visibility = View.VISIBLE
         } else {
             debugTimingTts.visibility = View.GONE

--- a/app/src/main/java/dev/klazomenai/deckchat/MainActivity.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/MainActivity.kt
@@ -46,8 +46,13 @@ class MainActivity : AppCompatActivity() {
     private var currentIndicatorColor: Int = 0
     private var colorAnimator: ValueAnimator? = null
     private var debugMode = false
+    private var showTimings = false
     private lateinit var debugUserText: TextView
     private lateinit var debugCrewText: TextView
+    private lateinit var debugTimingStt: TextView
+    private lateinit var debugTimingBridge: TextView
+    private lateinit var debugTimingTts: TextView
+    private lateinit var debugTimingTotal: TextView
 
     private val requestAudioPermission = registerForActivityResult(
         ActivityResultContracts.RequestPermission(),
@@ -77,10 +82,15 @@ class MainActivity : AppCompatActivity() {
         val stateIndicator = findViewById<View>(R.id.state_indicator)
         debugUserText = findViewById(R.id.debug_user_text)
         debugCrewText = findViewById(R.id.debug_crew_text)
+        debugTimingStt = findViewById(R.id.debug_timing_stt)
+        debugTimingBridge = findViewById(R.id.debug_timing_bridge)
+        debugTimingTts = findViewById(R.id.debug_timing_tts)
+        debugTimingTotal = findViewById(R.id.debug_timing_total)
         val settingsFab = findViewById<FloatingActionButton>(R.id.settings_fab)
         val pttFab = findViewById<FloatingActionButton>(R.id.ptt_fab)
 
         debugMode = storage.debugMode
+        showTimings = storage.showTimings
 
         settingsFab.setOnClickListener {
             startActivity(Intent(this, SettingsActivity::class.java))
@@ -116,7 +126,7 @@ class MainActivity : AppCompatActivity() {
 
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
-                combine(viewModel.lastUserText, viewModel.lastCrewResponse) { _, _ -> }
+                combine(viewModel.lastUserText, viewModel.lastCrewResponse, viewModel.lastTimings) { _, _, _ -> }
                     .collect { updateTranscript() }
             }
         }
@@ -125,17 +135,33 @@ class MainActivity : AppCompatActivity() {
     override fun onResume() {
         super.onResume()
         debugMode = storage.debugMode
+        showTimings = storage.showTimings
         updateTranscript()
     }
 
     private fun updateTranscript() {
         val userText = viewModel.lastUserText.value
         val crewMsg = viewModel.lastCrewResponse.value
+        val timings = viewModel.lastTimings.value
+        val timingsVisible = debugMode && showTimings && timings != null
+
         if (debugMode && userText != null) {
             debugUserText.text = getString(R.string.debug_transcript_you, userText)
             debugUserText.visibility = View.VISIBLE
         } else {
             debugUserText.visibility = View.GONE
+        }
+        if (timingsVisible && userText != null) {
+            debugTimingStt.text = getString(R.string.debug_timing_stt, formatDuration(timings!!.sttMs))
+            debugTimingStt.visibility = View.VISIBLE
+        } else {
+            debugTimingStt.visibility = View.GONE
+        }
+        if (timingsVisible && timings!!.bridgeMs != null) {
+            debugTimingBridge.text = getString(R.string.debug_timing_bridge, formatDuration(timings.bridgeMs))
+            debugTimingBridge.visibility = View.VISIBLE
+        } else {
+            debugTimingBridge.visibility = View.GONE
         }
         if (debugMode && crewMsg != null && userText != null) {
             val name = CrewRegistry.lookup(crewMsg.crewName).displayName
@@ -144,7 +170,19 @@ class MainActivity : AppCompatActivity() {
         } else {
             debugCrewText.visibility = View.GONE
         }
+        if (timingsVisible) {
+            debugTimingTts.text = getString(R.string.debug_timing_tts, formatDuration(timings!!.ttsMs))
+            debugTimingTts.visibility = View.VISIBLE
+            debugTimingTotal.text = getString(R.string.debug_timing_total, formatDuration(timings.totalMs))
+            debugTimingTotal.visibility = View.VISIBLE
+        } else {
+            debugTimingTts.visibility = View.GONE
+            debugTimingTotal.visibility = View.GONE
+        }
     }
+
+    private fun formatDuration(ms: Long): String =
+        String.format(java.util.Locale.ROOT, "%.1fs", ms / 1000.0)
 
     /**
      * Called by UI controls (FAB, headset) to initiate recording.

--- a/app/src/main/java/dev/klazomenai/deckchat/MainViewModel.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/MainViewModel.kt
@@ -50,6 +50,9 @@ class MainViewModel(
     private val _lastCrewResponse = MutableStateFlow<CrewMessage?>(null)
     val lastCrewResponse: StateFlow<CrewMessage?> = _lastCrewResponse.asStateFlow()
 
+    private val _lastTimings = MutableStateFlow<PipelineTimings?>(null)
+    val lastTimings: StateFlow<PipelineTimings?> = _lastTimings.asStateFlow()
+
     @VisibleForTesting
     internal val crewMessages = Channel<CrewMessage>(Channel.UNLIMITED)
     @Volatile
@@ -63,6 +66,7 @@ class MainViewModel(
                         _recordingDurationMs.value = 0L
                         _lastUserText.value = null
                         _lastCrewResponse.value = null
+                        _lastTimings.value = null
                         _state.value = PipelineState.Recording
                     }
                     is ServiceEvent.RecordingProgress -> {
@@ -131,8 +135,10 @@ class MainViewModel(
         viewModelScope.launch {
             try {
                 // STT
+                val sttStart = System.nanoTime()
                 val audioFile = audioFileProvider()
                 val text = sttEngine.transcribe(audioFile)
+                val sttMs = (System.nanoTime() - sttStart) / 1_000_000
 
                 if (text.isBlank()) {
                     _state.value = PipelineState.Idle
@@ -148,6 +154,7 @@ class MainViewModel(
                     while (crewMessages.tryReceive().isSuccess) { /* drain */ }
                     awaitingResponse = true
                     val response: CrewMessage
+                    val bridgeStart = System.nanoTime()
                     try {
                         _state.value = PipelineState.Processing("Sending")
                         withContext(ioDispatcher) { matrixClient.sendMessage(roomId, text) }
@@ -161,16 +168,25 @@ class MainViewModel(
                     } finally {
                         awaitingResponse = false
                     }
+                    val bridgeMs = (System.nanoTime() - bridgeStart) / 1_000_000
 
                     _lastCrewResponse.value = response
                     val displayName = CrewRegistry.lookup(response.crewName).displayName
                     _state.value = PipelineState.Speaking(displayName)
+                    val ttsStart = System.nanoTime()
                     ttsEngine.speak(response.crewName, response.body)
+                    val ttsMs = (System.nanoTime() - ttsStart) / 1_000_000
+
+                    _lastTimings.value = PipelineTimings(sttMs, bridgeMs, ttsMs)
                 } else {
                     // Local echo: TTS reads back transcription with default crew
                     val displayName = CrewRegistry.lookup(defaultCrew).displayName
                     _state.value = PipelineState.Speaking(displayName)
+                    val ttsStart = System.nanoTime()
                     ttsEngine.speak(defaultCrew, text)
+                    val ttsMs = (System.nanoTime() - ttsStart) / 1_000_000
+
+                    _lastTimings.value = PipelineTimings(sttMs, null, ttsMs)
                 }
 
                 _state.value = PipelineState.Idle
@@ -291,6 +307,15 @@ class MainViewModel(
         internal const val DEFAULT_CREW = "maren"
         internal const val DELEGATION_SETTLE_MS = 5_000L
     }
+}
+
+/** Pipeline stage durations in milliseconds. [bridgeMs] is null in local echo mode. */
+data class PipelineTimings(
+    val sttMs: Long,
+    val bridgeMs: Long?,
+    val ttsMs: Long,
+) {
+    val totalMs: Long get() = sttMs + (bridgeMs ?: 0) + ttsMs
 }
 
 /** Sentinel exception for response timeout — classified as [PipelineError.ResponseTimeout]. */

--- a/app/src/main/java/dev/klazomenai/deckchat/SecureStorage.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/SecureStorage.kt
@@ -81,6 +81,11 @@ class SecureStorage(
         get() = prefs.getBoolean(KEY_DEBUG_MODE, false)
         set(value) = prefs.edit().putBoolean(KEY_DEBUG_MODE, value).apply()
 
+    /** Show pipeline timings inline with debug transcript. Requires debugMode. */
+    var showTimings: Boolean
+        get() = prefs.getBoolean(KEY_SHOW_TIMINGS, false)
+        set(value) = prefs.edit().putBoolean(KEY_SHOW_TIMINGS, value).apply()
+
     /** Response timeout in seconds. Default 60s — covers crew delegation chains. */
     var responseTimeoutSec: Int
         get() = prefs.getInt(KEY_RESPONSE_TIMEOUT_SEC, DEFAULT_RESPONSE_TIMEOUT_SEC)
@@ -227,6 +232,7 @@ class SecureStorage(
         private const val KEY_SQLITE_PASSPHRASE = "sqlite_passphrase"
         private const val KEY_RESPONSE_TIMEOUT_SEC = "response_timeout_sec"
         private const val KEY_DEBUG_MODE = "debug_mode"
+        private const val KEY_SHOW_TIMINGS = "show_timings"
         const val DEFAULT_RESPONSE_TIMEOUT_SEC = 60
         const val MIN_RESPONSE_TIMEOUT_SEC = 15
         const val MAX_RESPONSE_TIMEOUT_SEC = 300

--- a/app/src/main/java/dev/klazomenai/deckchat/SettingsActivity.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/SettingsActivity.kt
@@ -29,6 +29,7 @@ class SettingsActivity : AppCompatActivity() {
         val roomIdInput = findViewById<EditText>(R.id.room_id_input)
         val timeoutInput = findViewById<EditText>(R.id.response_timeout_input)
         val debugSwitch = findViewById<SwitchMaterial>(R.id.debug_mode_switch)
+        val timingsSwitch = findViewById<SwitchMaterial>(R.id.show_timings_switch)
         val statusText = findViewById<TextView>(R.id.session_status)
         val saveButton = findViewById<Button>(R.id.save_button)
         val clearButton = findViewById<Button>(R.id.clear_session_button)
@@ -38,6 +39,7 @@ class SettingsActivity : AppCompatActivity() {
         roomIdInput.setText(storage.roomId ?: "")
         timeoutInput.setText(storage.responseTimeoutSec.toString())
         debugSwitch.isChecked = storage.debugMode
+        timingsSwitch.isChecked = storage.showTimings
         updateSessionStatus(statusText)
 
         saveButton.setOnClickListener {
@@ -69,6 +71,7 @@ class SettingsActivity : AppCompatActivity() {
             storage.roomId = roomId.ifEmpty { null }
             storage.responseTimeoutSec = timeoutSec
             storage.debugMode = debugSwitch.isChecked
+            storage.showTimings = timingsSwitch.isChecked
 
             updateSessionStatus(statusText)
             Toast.makeText(this, "Saved", Toast.LENGTH_SHORT).show()

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -59,6 +59,30 @@
             android:paddingStart="24dp"
             android:paddingEnd="24dp" />
 
+        <!-- Debug timing: STT duration -->
+        <TextView
+            android:id="@+id/debug_timing_stt"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="2dp"
+            android:textSize="12sp"
+            android:textColor="?android:attr/textColorSecondary"
+            android:visibility="gone"
+            android:paddingStart="24dp"
+            android:paddingEnd="24dp" />
+
+        <!-- Debug timing: bridge duration -->
+        <TextView
+            android:id="@+id/debug_timing_bridge"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:textSize="12sp"
+            android:textColor="?android:attr/textColorSecondary"
+            android:visibility="gone"
+            android:paddingStart="24dp"
+            android:paddingEnd="24dp" />
+
         <!-- Debug transcript: last crew response -->
         <TextView
             android:id="@+id/debug_crew_text"
@@ -70,6 +94,31 @@
             android:visibility="gone"
             android:maxLines="5"
             android:ellipsize="end"
+            android:paddingStart="24dp"
+            android:paddingEnd="24dp" />
+
+        <!-- Debug timing: TTS duration -->
+        <TextView
+            android:id="@+id/debug_timing_tts"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="2dp"
+            android:textSize="12sp"
+            android:textColor="?android:attr/textColorSecondary"
+            android:visibility="gone"
+            android:paddingStart="24dp"
+            android:paddingEnd="24dp" />
+
+        <!-- Debug timing: total duration -->
+        <TextView
+            android:id="@+id/debug_timing_total"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:textSize="12sp"
+            android:textColor="?android:attr/textColorSecondary"
+            android:textStyle="bold"
+            android:visibility="gone"
             android:paddingStart="24dp"
             android:paddingEnd="24dp" />
 

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -69,6 +69,13 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/debug_mode_label"
+        android:layout_marginBottom="8dp" />
+
+    <com.google.android.material.switchmaterial.SwitchMaterial
+        android:id="@+id/show_timings_switch"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/show_timings_label"
         android:layout_marginBottom="16dp" />
 
     <Button

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,8 +12,13 @@
     <string name="response_timeout_range_error">Enter a value between 15 and 300 seconds</string>
     <string name="debug_heading">Debug</string>
     <string name="debug_mode_label">Show transcript</string>
+    <string name="show_timings_label">Show timings</string>
     <string name="debug_transcript_you">You: %1$s</string>
     <string name="debug_transcript_crew">%1$s: %2$s</string>
+    <string name="debug_timing_stt">STT: %1$s</string>
+    <string name="debug_timing_bridge">Bridge: %1$s</string>
+    <string name="debug_timing_tts">TTS: %1$s</string>
+    <string name="debug_timing_total">Total: %1$s</string>
 
     <string name="session_heading">Matrix Session</string>
     <string name="session_active">Logged in as %1$s</string>

--- a/app/src/test/java/dev/klazomenai/deckchat/MainViewModelTest.kt
+++ b/app/src/test/java/dev/klazomenai/deckchat/MainViewModelTest.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -320,6 +321,57 @@ class MainViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertNull(viewModel.lastUserText.value)
+    }
+
+    // --- Pipeline timings ---
+
+    @Test
+    fun `lastTimings defaults to null`() {
+        val viewModel = createViewModel()
+        assertNull(viewModel.lastTimings.value)
+    }
+
+    @Test
+    fun `recording started clears timings`() = runTest {
+        val viewModel = createViewModel(sttResult = "hello")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Run pipeline to set timings (local echo)
+        RecordingService.emitEvent(ServiceEvent.RecordingStopped)
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertNotNull(viewModel.lastTimings.value)
+
+        // New recording should clear
+        RecordingService.emitEvent(ServiceEvent.RecordingStarted)
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertNull(viewModel.lastTimings.value)
+    }
+
+    @Test
+    fun `local echo pipeline sets stt and tts timings with null bridge`() = runTest {
+        val viewModel = createViewModel(sttResult = "hello")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        RecordingService.emitEvent(ServiceEvent.RecordingStopped)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val timings = viewModel.lastTimings.value
+        assertNotNull(timings)
+        assertTrue(timings!!.sttMs >= 0)
+        assertNull(timings.bridgeMs)
+        assertTrue(timings.ttsMs >= 0)
+        assertTrue(timings.totalMs >= 0)
+    }
+
+    @Test
+    fun `blank STT does not set timings`() = runTest {
+        val viewModel = createViewModel(sttResult = "")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        RecordingService.emitEvent(ServiceEvent.RecordingStopped)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertNull(viewModel.lastTimings.value)
     }
 
     // --- Delegation settling ---

--- a/app/src/test/java/dev/klazomenai/deckchat/SecureStorageTest.kt
+++ b/app/src/test/java/dev/klazomenai/deckchat/SecureStorageTest.kt
@@ -193,6 +193,21 @@ class SecureStorageTest {
     }
 
     @Test
+    fun `showTimings defaults to false`() {
+        val storage = createStorage()
+        assertFalse(storage.showTimings)
+    }
+
+    @Test
+    fun `showTimings round-trips`() {
+        val storage = createStorage()
+        storage.showTimings = true
+        assertTrue(storage.showTimings)
+        storage.showTimings = false
+        assertFalse(storage.showTimings)
+    }
+
+    @Test
     fun `responseTimeoutSec getter clamps out-of-range stored value to minimum`() {
         val storage = createStorage()
         // Write an out-of-range value directly to prefs (simulates corruption or upgrade)


### PR DESCRIPTION
## Summary

- Add "Show timings" toggle in Settings under Debug section (off by default)
- Capture STT, bridge, and TTS durations in `runPipeline()` via `System.nanoTime()`
- Display timings inline with debug transcript: STT after user text, bridge before crew response, TTS + total after crew response
- Bridge timing line hidden in local echo mode (no Matrix)
- `PipelineTimings` data class with nullable `bridgeMs`

## Test plan

- [x] Toggle both "Show transcript" and "Show timings" on → see timing lines after each stage
- [x] Toggle "Show timings" off, keep transcript on → timings disappear, transcript stays
- [x] Toggle both off → clean main screen
- [x] Local echo mode → no bridge line, STT + TTS + Total shown
- [x] Timings clear on new recording
- [x] CI passes

### Tests added

- `showTimings defaults to false`
- `showTimings round-trips`
- `lastTimings defaults to null`
- `recording started clears timings`
- `local echo pipeline sets stt and tts timings with null bridge`
- `blank STT does not set timings`

Refs #164