### PR TITLE
feat: enable E2EE key backup and UTD handling ✨

### DIFF
--- a/app/src/main/java/dev/klazomenai/deckchat/RustMatrixClient.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/RustMatrixClient.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.json.JSONObject
+import uniffi.matrix_sdk.BackupDownloadStrategy
 import org.matrix.rustcomponents.sdk.Client
 import org.matrix.rustcomponents.sdk.ClientBuilder
 import org.matrix.rustcomponents.sdk.MessageType
@@ -22,6 +23,8 @@ import org.matrix.rustcomponents.sdk.TimelineDiff
 import org.matrix.rustcomponents.sdk.TimelineItem
 import org.matrix.rustcomponents.sdk.TimelineItemContent
 import org.matrix.rustcomponents.sdk.TimelineListener
+import org.matrix.rustcomponents.sdk.UnableToDecryptDelegate
+import org.matrix.rustcomponents.sdk.UnableToDecryptInfo
 import java.io.File
 
 /**
@@ -50,6 +53,7 @@ class RustMatrixClient(
     override suspend fun login(homeserverUrl: String, username: String, password: String) {
         val client = buildClient(homeserverUrl)
         client.login(username, password, "DeckChat Android", null)
+        client.encryption().waitForE2eeInitializationTasks()
 
         val session = client.session()
         persistSession(session)
@@ -65,6 +69,7 @@ class RustMatrixClient(
             ?: throw IllegalStateException("No session stored")
 
         client.restoreSession(session)
+        client.encryption().waitForE2eeInitializationTasks()
         this.client = client
     }
 
@@ -170,13 +175,22 @@ class RustMatrixClient(
         val dataDir = File(context.filesDir, "matrix-data").apply { mkdirs() }
         val cacheDir = File(context.cacheDir, "matrix-cache").apply { mkdirs() }
 
-        // SDK manages SQLite store encryption internally via sessionPaths.
-        // No explicit passphrase method exists on ClientBuilder.
-        return ClientBuilder()
+        val client = ClientBuilder()
             .homeserverUrl(homeserverUrl)
             .slidingSyncVersionBuilder(SlidingSyncVersionBuilder.DISCOVER_NATIVE)
             .sessionPaths(dataDir.absolutePath, cacheDir.absolutePath)
+            .autoEnableBackups(true)
+            .autoEnableCrossSigning(true)
+            .backupDownloadStrategy(BackupDownloadStrategy.AFTER_DECRYPTION_FAILURE)
             .build()
+
+        client.setUtdDelegate(object : UnableToDecryptDelegate {
+            override fun onUtd(info: UnableToDecryptInfo) {
+                Log.w(TAG, "UTD: event=${info.eventId} cause=${info.cause}")
+            }
+        })
+
+        return client
     }
 
     private fun persistSession(session: Session) {
@@ -225,6 +239,10 @@ class RustMatrixClient(
         val content = event.content
         if (content !is TimelineItemContent.MsgLike) return
         val kind = content.content.kind
+        if (kind is MsgLikeKind.UnableToDecrypt) {
+            Log.w(TAG, "UTD: message from ${event.sender} could not be decrypted")
+            return
+        }
         if (kind !is MsgLikeKind.Message) return
         val msgType = kind.content.msgType
         if (msgType !is MessageType.Text) return


### PR DESCRIPTION
## Summary

- Enable auto key backup and cross-signing on `ClientBuilder`
- Set `AFTER_DECRYPTION_FAILURE` download strategy so the SDK fetches backed-up megolm keys when it can't decrypt a message
- Wait for E2EE initialization after login and session restore
- Log UTD events in timeline processing and via `UnableToDecryptDelegate`

## How it helps

After reinstalling the app (new device ID), the SDK should automatically download backed-up megolm session keys from the server when it encounters undecryptable messages. This reduces the need for bridge pod restarts after reinstall.

## Test plan

- [ ] Build compiles (SDK APIs verified against v26.03.19)
- [ ] `install-debug` — baseline: crew responds normally
- [ ] Reinstall app with `install-debug` (new device ID)
- [ ] Send a message — check if crew response is decryptable without bridge restart
- [ ] If decryption fails, check logcat for UTD cause: `adb logcat -s DeckChat.MatrixClient`
- [ ] CI passes

## Bridge follow-up (separate issues)

These complement the deck-chat changes but require bridge-side work:

- Override `AllowKeyShare` for room members (~10 lines in `bot.go`)
- Force megolm session rotation on bridge startup (~5 lines)
- Add device list change logging for Tuwunel verification

Refs #141