### PR TITLE
feat: surface UTD events in debug transcript ✨

### DIFF
--- a/app/src/main/java/dev/klazomenai/deckchat/MainActivity.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/MainActivity.kt
@@ -53,6 +53,7 @@ class MainActivity : AppCompatActivity() {
     private lateinit var debugTimingBridge: TextView
     private lateinit var debugTimingTts: TextView
     private lateinit var debugTimingTotal: TextView
+    private lateinit var debugUtdText: TextView
 
     private val requestAudioPermission = registerForActivityResult(
         ActivityResultContracts.RequestPermission(),
@@ -86,6 +87,7 @@ class MainActivity : AppCompatActivity() {
         debugTimingBridge = findViewById(R.id.debug_timing_bridge)
         debugTimingTts = findViewById(R.id.debug_timing_tts)
         debugTimingTotal = findViewById(R.id.debug_timing_total)
+        debugUtdText = findViewById(R.id.debug_utd_text)
         val settingsFab = findViewById<FloatingActionButton>(R.id.settings_fab)
         val pttFab = findViewById<FloatingActionButton>(R.id.ptt_fab)
 
@@ -126,7 +128,7 @@ class MainActivity : AppCompatActivity() {
 
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
-                combine(viewModel.lastUserText, viewModel.lastCrewResponse, viewModel.lastTimings) { _, _, _ -> }
+                combine(viewModel.lastUserText, viewModel.lastCrewResponse, viewModel.lastTimings, viewModel.lastUtd) { _, _, _, _ -> }
                     .collect { updateTranscript() }
             }
         }
@@ -179,6 +181,15 @@ class MainActivity : AppCompatActivity() {
         } else {
             debugTimingTts.visibility = View.GONE
             debugTimingTotal.visibility = View.GONE
+        }
+        val utd = viewModel.lastUtd.value
+        if (debugMode && utd != null) {
+            val sender = utd.sender ?: getString(R.string.debug_utd_unknown_sender)
+            val shortId = utd.eventId.take(UTD_EVENT_ID_DISPLAY_LEN)
+            debugUtdText.text = getString(R.string.debug_utd, sender, shortId, utd.cause)
+            debugUtdText.visibility = View.VISIBLE
+        } else {
+            debugUtdText.visibility = View.GONE
         }
     }
 
@@ -352,6 +363,7 @@ class MainActivity : AppCompatActivity() {
     companion object {
         private const val CROSSFADE_DURATION_MS = 300L
         private const val COLOR_FADE_DURATION_MS = 400L
+        private const val UTD_EVENT_ID_DISPLAY_LEN = 12
     }
 
     private fun updatePttFab(state: PipelineState, fab: FloatingActionButton) {

--- a/app/src/main/java/dev/klazomenai/deckchat/MainViewModel.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/MainViewModel.kt
@@ -11,8 +11,11 @@ import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
@@ -52,6 +55,16 @@ class MainViewModel(
 
     private val _lastTimings = MutableStateFlow<PipelineTimings?>(null)
     val lastTimings: StateFlow<PipelineTimings?> = _lastTimings.asStateFlow()
+
+    /**
+     * Most recent undecryptable event from the Matrix client, or null if none.
+     * Surfaced in the debug transcript to diagnose E2EE key issues (see #167).
+     */
+    val lastUtd: StateFlow<UtdEvent?> =
+        matrixClient?.utdEvents
+            ?.map { it.lastOrNull() }
+            ?.stateIn(viewModelScope, SharingStarted.Eagerly, null)
+            ?: MutableStateFlow(null).asStateFlow()
 
     @VisibleForTesting
     internal val crewMessages = Channel<CrewMessage>(Channel.UNLIMITED)

--- a/app/src/main/java/dev/klazomenai/deckchat/MatrixClient.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/MatrixClient.kt
@@ -1,5 +1,7 @@
 package dev.klazomenai.deckchat
 
+import kotlinx.coroutines.flow.StateFlow
+
 /**
  * Matrix client abstraction for E2EE messaging.
  *
@@ -27,7 +29,26 @@ interface MatrixClient {
     /** Stops syncing. Does NOT clear the session or log out. */
     suspend fun stop()
     fun isLoggedIn(): Boolean
+
+    /**
+     * Recent undecryptable events, newest last. Bounded to the most recent entries.
+     * Surfaced via the debug transcript (issue #167) for diagnosing key backup /
+     * cross-signing issues without needing `adb logcat`.
+     */
+    val utdEvents: StateFlow<List<UtdEvent>>
 }
+
+/**
+ * A single UTD (unable-to-decrypt) observation. `sender` is only populated when the
+ * event surfaces via the room timeline — the SDK's global UTD delegate does not
+ * expose it directly.
+ */
+data class UtdEvent(
+    val eventId: String,
+    val sender: String?,
+    val cause: String,
+    val timestampMs: Long,
+)
 
 /**
  * Parsed crew response from a Matrix message body prefix.

--- a/app/src/main/java/dev/klazomenai/deckchat/RustMatrixClient.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/RustMatrixClient.kt
@@ -7,11 +7,16 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.json.JSONObject
 import uniffi.matrix_sdk.BackupDownloadStrategy
 import org.matrix.rustcomponents.sdk.Client
 import org.matrix.rustcomponents.sdk.ClientBuilder
+import org.matrix.rustcomponents.sdk.EventOrTransactionId
 import org.matrix.rustcomponents.sdk.MessageType
 import org.matrix.rustcomponents.sdk.MsgLikeKind
 import org.matrix.rustcomponents.sdk.Session
@@ -49,6 +54,9 @@ class RustMatrixClient(
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     @Volatile
     private var onSyncStatusCallback: ((String) -> Unit)? = null
+
+    private val _utdEvents = MutableStateFlow<List<UtdEvent>>(emptyList())
+    override val utdEvents: StateFlow<List<UtdEvent>> = _utdEvents.asStateFlow()
 
     override suspend fun login(homeserverUrl: String, username: String, password: String) {
         val client = buildClient(homeserverUrl)
@@ -187,6 +195,7 @@ class RustMatrixClient(
         client.setUtdDelegate(object : UnableToDecryptDelegate {
             override fun onUtd(info: UnableToDecryptInfo) {
                 Log.w(TAG, "UTD: event=${info.eventId} cause=${info.cause}")
+                recordUtd(info.eventId, sender = null, cause = info.cause.toString())
             }
         })
 
@@ -241,6 +250,8 @@ class RustMatrixClient(
         val kind = content.content.kind
         if (kind is MsgLikeKind.UnableToDecrypt) {
             Log.w(TAG, "UTD: message from ${event.sender} could not be decrypted")
+            val eventId = (event.eventOrTransactionId as? EventOrTransactionId.EventId)?.eventId ?: "?"
+            recordUtd(eventId, sender = event.sender, cause = "timeline-drop")
             return
         }
         if (kind !is MsgLikeKind.Message) return
@@ -252,9 +263,22 @@ class RustMatrixClient(
         onMessageCallback?.invoke(crewMessage)
     }
 
+    private fun recordUtd(eventId: String, sender: String?, cause: String) {
+        val event = UtdEvent(
+            eventId = eventId,
+            sender = sender,
+            cause = cause,
+            timestampMs = System.currentTimeMillis(),
+        )
+        _utdEvents.update { existing ->
+            (existing + event).takeLast(MAX_UTD_EVENTS)
+        }
+    }
+
     companion object {
         private const val TAG = "DeckChat.MatrixClient"
         private const val ROOM_SYNC_TIMEOUT_MS = 30_000L
         private const val ROOM_SYNC_POLL_MS = 250L
+        private const val MAX_UTD_EVENTS = 20
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -122,6 +122,20 @@
             android:paddingStart="24dp"
             android:paddingEnd="24dp" />
 
+        <!-- Debug: latest undecryptable event (issue #167) -->
+        <TextView
+            android:id="@+id/debug_utd_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:textSize="12sp"
+            android:textColor="?android:attr/colorError"
+            android:visibility="gone"
+            android:maxLines="3"
+            android:ellipsize="end"
+            android:paddingStart="24dp"
+            android:paddingEnd="24dp" />
+
     </LinearLayout>
 
     <!-- Push-to-talk FAB (bottom-center) -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,8 @@
     <string name="debug_timing_bridge">Bridge: %1$s</string>
     <string name="debug_timing_tts">TTS: %1$s</string>
     <string name="debug_timing_total">Total: %1$s</string>
+    <string name="debug_utd">UTD: %1$s %2$s (%3$s)</string>
+    <string name="debug_utd_unknown_sender">?</string>
 
     <string name="session_heading">Matrix Session</string>
     <string name="session_active">Logged in as %1$s</string>

--- a/app/src/test/java/dev/klazomenai/deckchat/MainViewModelTest.kt
+++ b/app/src/test/java/dev/klazomenai/deckchat/MainViewModelTest.kt
@@ -374,6 +374,55 @@ class MainViewModelTest {
         assertNull(viewModel.lastTimings.value)
     }
 
+    // --- UTD surface (#167) ---
+
+    @Test
+    fun `lastUtd defaults to null when no matrix client`() {
+        val viewModel = createViewModel()
+        assertNull(viewModel.lastUtd.value)
+    }
+
+    @Test
+    fun `lastUtd defaults to null with matrix client and no events`() = runTest {
+        val client = MockMatrixClient()
+        val viewModel = createViewModel(matrixClient = client, roomId = "!room:example.com")
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertNull(viewModel.lastUtd.value)
+    }
+
+    @Test
+    fun `lastUtd updates when matrix client emits UTD event`() = runTest {
+        val client = MockMatrixClient()
+        val viewModel = createViewModel(matrixClient = client, roomId = "!room:example.com")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val event = UtdEvent(
+            eventId = "\$abc123",
+            sender = "@bot:example.com",
+            cause = "UNKNOWN_DEVICE",
+            timestampMs = 1_700_000_000_000L,
+        )
+        client.simulateUtd(event)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(event, viewModel.lastUtd.value)
+    }
+
+    @Test
+    fun `lastUtd reflects most recent UTD when multiple emitted`() = runTest {
+        val client = MockMatrixClient()
+        val viewModel = createViewModel(matrixClient = client, roomId = "!room:example.com")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val first = UtdEvent("\$a", "@a:example.com", "UNKNOWN_DEVICE", 1L)
+        val second = UtdEvent("\$b", "@b:example.com", "WITHHELD_BY_SENDER", 2L)
+        client.simulateUtd(first)
+        client.simulateUtd(second)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(second, viewModel.lastUtd.value)
+    }
+
     // --- Delegation settling ---
 
     private fun createOnlineViewModel(

--- a/app/src/test/java/dev/klazomenai/deckchat/MatrixClientTest.kt
+++ b/app/src/test/java/dev/klazomenai/deckchat/MatrixClientTest.kt
@@ -69,9 +69,14 @@ class MockMatrixClient(
         onMessageCallback?.invoke(crewMessage)
     }
 
-    /** Simulate a UTD event surfacing via the Matrix client. */
+    /** Simulate a UTD event surfacing via the Matrix client. Mirrors the
+     *  production cap so the mock honours the interface contract. */
     fun simulateUtd(event: UtdEvent) {
-        _utdEvents.value = _utdEvents.value + event
+        _utdEvents.value = (_utdEvents.value + event).takeLast(MAX_UTD_EVENTS)
+    }
+
+    companion object {
+        private const val MAX_UTD_EVENTS = 20
     }
 }
 

--- a/app/src/test/java/dev/klazomenai/deckchat/MatrixClientTest.kt
+++ b/app/src/test/java/dev/klazomenai/deckchat/MatrixClientTest.kt
@@ -1,5 +1,8 @@
 package dev.klazomenai.deckchat
 
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -58,9 +61,17 @@ class MockMatrixClient(
 
     override fun isLoggedIn(): Boolean = loggedIn
 
+    private val _utdEvents = MutableStateFlow<List<UtdEvent>>(emptyList())
+    override val utdEvents: StateFlow<List<UtdEvent>> = _utdEvents.asStateFlow()
+
     /** Simulate receiving a message (for testing downstream handlers) */
     fun simulateMessage(crewMessage: CrewMessage) {
         onMessageCallback?.invoke(crewMessage)
+    }
+
+    /** Simulate a UTD event surfacing via the Matrix client. */
+    fun simulateUtd(event: UtdEvent) {
+        _utdEvents.value = _utdEvents.value + event
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds `UtdEvent` data class and `utdEvents: StateFlow<List<UtdEvent>>` to the `MatrixClient` interface.
- `RustMatrixClient` backs the flow with a bounded list (cap 20) and records from both the UTD delegate (cause source, added in #166) and the timeline `MsgLikeKind.UnableToDecrypt` branch (sender + eventId via `EventOrTransactionId.EventId`).
- `MainViewModel` surfaces the most recent UTD as `lastUtd`; `MainActivity` renders it in the debug transcript, error-tinted, as `UTD: <sender|?> <short-eventId> (<cause>)`.
- Visibility is gated by the existing `debugMode` toggle — consistent with `debug_user_text` / `debug_crew_text`.
- `MockMatrixClient` gains a `simulateUtd()` helper for tests.

## Why

Diagnosing UTDs previously required `adb logcat -s DeckChat.MatrixClient`. The delegate registered in #166 only logged; this surfaces it on-device so the pipeline's E2EE health is visible during normal debug use.

## Test plan

- [x] `./gradlew test` — green
- [x] `./gradlew lint` — green
- [x] Install on device, confirm existing transcript/timings unchanged when no UTDs occur
- [x] Trigger a UTD (e.g. reinstall app and receive crew reply before key backup recovers) — confirm the red UTD line appears and reports `sender`, short event ID, and cause

## Refs

- Refs #167
- Builds on #166 (E2EE key backup + UTD delegate), #156 (debug transcript), #165 (pipeline timings)
