### PR TITLE
refactor(ci): use grouped redirect in release-please.yml summary step ♻️

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -82,9 +82,11 @@ jobs:
 
       - name: Summary
         run: |
-          echo "## Signed APK Published" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Version:** \`${{ needs.release-please.outputs.version }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Tag:** \`${{ needs.release-please.outputs.tag_name }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "Download: [deck-chat-${{ needs.release-please.outputs.version }}.apk](https://github.com/${{ github.repository }}/releases/download/${{ needs.release-please.outputs.tag_name }}/deck-chat-${{ needs.release-please.outputs.version }}.apk)" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Signed APK Published"
+            echo ""
+            echo "**Version:** \`${{ needs.release-please.outputs.version }}\`"
+            echo "**Tag:** \`${{ needs.release-please.outputs.tag_name }}\`"
+            echo ""
+            echo "Download: [deck-chat-${{ needs.release-please.outputs.version }}.apk](https://github.com/${{ github.repository }}/releases/download/${{ needs.release-please.outputs.tag_name }}/deck-chat-${{ needs.release-please.outputs.version }}.apk)"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## 🏴‍☠️ Quartermaster's note

Tighten one rope before the new lookout boards. The "Summary" step in `release-please.yml`'s `build-apk` job uses 4 separate `>> "$GITHUB_STEP_SUMMARY"` redirects where one grouped redirect would do. shellcheck flags this as `SC2129` (style). Fix it before the actionlint workflow lands so the new lint job (#173) passes on day one.

## What changed

Replaced the individual-redirect pattern in `.github/workflows/release-please.yml`'s "Summary" step with a single grouped redirect:

```yaml
# Before
run: |
  echo "## Signed APK Published" >> "$GITHUB_STEP_SUMMARY"
  echo "" >> "$GITHUB_STEP_SUMMARY"
  echo "**Version:** ..." >> "$GITHUB_STEP_SUMMARY"
  echo "**Tag:** ..." >> "$GITHUB_STEP_SUMMARY"
  echo "" >> "$GITHUB_STEP_SUMMARY"
  echo "Download: ..." >> "$GITHUB_STEP_SUMMARY"

# After
run: |
  {
    echo "## Signed APK Published"
    echo ""
    echo "**Version:** ..."
    echo "**Tag:** ..."
    echo ""
    echo "Download: ..."
  } >> "$GITHUB_STEP_SUMMARY"
```

## Why

- shellcheck `SC2129` (style): "Consider using `{ cmd1; cmd2; } >> file` instead of individual redirects". One open/close instead of N, and the grouped form signals intent that the block is one logical write.
- Pre-requisite for #173 (introducing `actionlint` to devenv + a new `lint-workflows.yml` workflow). #173's acceptance criterion is "all existing workflow files pass `actionlint` after the change (no regression)" — this finding is the only blocker between today's `main` and a green run of the new lint job. Fixing it in this small, separate PR keeps #173 scoped to "introduce actionlint" rather than "introduce actionlint AND fix every existing finding".
- Avoids tempting future-us to suppress `SC2129` globally via an `actionlint.yaml` config, which would hide real findings of the same shape elsewhere.

## Verification

- [x] `nix run nixpkgs#actionlint -- .github/workflows/release-please.yml` exits 0 (with `actionlint 1.7.12`)
- [x] Diff is `+8 / -6` — only the redirect form changes; the actual text written to `$GITHUB_STEP_SUMMARY` is byte-identical
- [x] Commit GPG-signed
- [ ] Copilot review pending

## Acceptance criteria mapping (#174)

- [x] `release-please.yml` "Summary" step uses one grouped `{ ... } >> "$GITHUB_STEP_SUMMARY"` redirect instead of N individual redirects
- [x] Step content (the actual text written to the summary) is byte-identical — only the redirect form changes
- [x] No behavioural change to the next release run (Summary still renders the same in the GitHub Actions UI)
- [ ] `nix develop --command actionlint` reports zero findings on `release-please.yml` — **deferred until #173 lands `devenv` actionlint**; verified manually via `nix run nixpkgs#actionlint` ad-hoc

## Related

- Refs #174 — this PR
- Blocks #173 — actionlint setup PR cannot land cleanly until this lands

🏴‍☠️ Logged by the Quartermaster. All hands review before we set sail.
