### PR TITLE
chore(ci): add actionlint to devenv and CI workflow 🏗️

### DIFF
--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -1,0 +1,34 @@
+name: Lint Workflows
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - 'devenv.nix'
+      - 'devenv.lock'
+      - 'flake.nix'
+      - 'flake.lock'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - 'devenv.nix'
+      - 'devenv.lock'
+      - 'flake.nix'
+      - 'flake.lock'
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: DeterminateSystems/nix-installer-action@v14
+
+      - uses: DeterminateSystems/magic-nix-cache-action@v8
+
+      - name: Run actionlint
+        run: nix develop --command actionlint -color

--- a/devenv.nix
+++ b/devenv.nix
@@ -37,6 +37,7 @@ in
     pkgs.gnutar
     pkgs.bzip2
     pkgs.actionlint
+    pkgs.shellcheck
   ];
 
   env = {

--- a/devenv.nix
+++ b/devenv.nix
@@ -36,6 +36,7 @@ in
     pkgs.curl
     pkgs.gnutar
     pkgs.bzip2
+    pkgs.actionlint
   ];
 
   env = {
@@ -167,6 +168,7 @@ in
     echo "  download-models            — Download STT + TTS model files"
     echo "  wrapper                    — Regenerate Gradle wrapper (9.4.0)"
     echo "  check-gms                  — Audit for Google Play Services deps"
+    echo "  actionlint                 — Lint .github/workflows/*.yml"
     echo ""
     if [ -e /dev/kvm ] && [ ! -w /dev/kvm ]; then
       echo "⚠  /dev/kvm not accessible — emulator will be slow without KVM."

--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,8 @@
               pkgs.jdk17
               pkgs.gradle
               androidComposition.androidsdk
+              pkgs.actionlint
+              pkgs.shellcheck
             ];
 
             # Set Android SDK paths as shell environment variables.


### PR DESCRIPTION
## 🏴‍☠️ Quartermaster's note

`actionlint` (with its `shellcheck` integration) joins **both** dev shell definitions in this repo, and a new dedicated `lint-workflows.yml` workflow enforces the lint on every PR that touches workflow files or dev-shell composition. The CI gate is honest: it uses the same binary, from the same nixpkgs lock, that contributors get locally.

## What changed

```
devenv.nix                            (+3 lines: pkgs.actionlint, pkgs.shellcheck, banner line)
flake.nix                             (+2 lines: pkgs.actionlint, pkgs.shellcheck)
.github/workflows/lint-workflows.yml  (NEW — paths-scoped actionlint job, 33 lines)
```

### `devenv.nix` — local development shell (entered via `devenv shell`)

- Added `pkgs.actionlint` to `packages`. Local invocation: `devenv shell -- actionlint`, or just `actionlint` from inside the shell.
- Added `pkgs.shellcheck` to `packages` so actionlint's shellcheck integration runs locally — without it, findings like `SC2129` silently skip on contributor machines.
- One line in the welcome banner under "Setup" so contributors discover the lint command on shell entry.

### `flake.nix` — CI dev shell (entered via `nix develop`)

- Added `pkgs.actionlint` and `pkgs.shellcheck` to `devShells.default.packages`. These are the same nixpkgs derivations used by `devenv.nix`, so versions stay in lockstep via `flake.lock`.

### `.github/workflows/lint-workflows.yml` — new workflow

```yaml
on:
  push:
    branches: [main]
    paths: [.github/workflows/**, devenv.nix, devenv.lock, flake.nix, flake.lock]
  pull_request:
    paths: [.github/workflows/**, devenv.nix, devenv.lock, flake.nix, flake.lock]

permissions:
  contents: read

jobs:
  actionlint:
    steps:
      - actions/checkout@v4
      - DeterminateSystems/nix-installer-action@v14
      - DeterminateSystems/magic-nix-cache-action@v8
      - run: nix develop --command actionlint -color
```

## Why touch both `devenv.nix` and `flake.nix`?

This repo maintains **two parallel dev shell definitions** — a deliberate split documented in `flake.nix`:

```
# CI-only: no emulator or system images (saves ~4 GB).
# Local development uses devenv shell which includes emulator.
```

| Shell file | Loaded by | Used for | Includes |
|---|---|---|---|
| `devenv.nix` | `devenv shell` | local development | full Android SDK + emulator + system images + dev scripts |
| `flake.nix` `devShells.default` | `nix develop` | CI workflows | slim: jdk17, gradle, androidsdk-without-emulator |

`actionlint` (and `shellcheck`) belong in **both** because:
- The new `lint-workflows.yml` job runs `nix develop --command actionlint` → it loads `flake.nix`'s shell. Without `pkgs.actionlint` there, CI fails with `actionlint: not found` (this was the failure mode of commit `152e408`, fixed in `2309502`).
- Contributors run `devenv shell -- actionlint` locally → it loads `devenv.nix`'s shell. Without `pkgs.actionlint` there, the canonical local workflow doesn't expose the linter.
- Without `pkgs.shellcheck` in either shell, actionlint's integrated shellcheck checks (which produce findings like `SC2129`) silently skip — contributors and CI would diverge in what findings they report.

Keeping the lists parallel rather than collapsing them is the established pattern; collapsing would bloat CI by ~4 GB of unused emulator/system-image artefacts.

## Why a separate workflow file rather than a job in `ci.yml`?

GitHub Actions `paths` filters are **workflow-scope, not job-scope**. The existing `ci.yml` runs `build` (gradle lint/test/assembleRelease) and `instrumented-tests` (emulator) — both of which must continue to run on every code PR. If `paths: [.github/workflows/**]` were added to `ci.yml`, it would scope all jobs in the file, breaking the regular CI for code-only PRs. Job-level path filters aren't a native feature, so the cleanest answer is a single-purpose workflow file with the path filter at the top.

## Why `nix develop --command actionlint` rather than a marketplace action?

- Same binary as the local dev shell — no divergence between what runs on a contributor's laptop and what CI enforces.
- The runner is already nix-installer-action + magic-nix-cache-action equipped (matches the existing `release-please.yml` pattern), so the dev shell loads in seconds with cache.
- One source of truth for the actionlint version: `flake.lock` (`devenv.lock` for the local shell pulls from the same nixpkgs).
- Bumping nixpkgs bumps actionlint and shellcheck in lockstep across local and CI.

## Verification

Tested with the **exact CI invocation**:

```
$ nix develop --command bash -c 'actionlint --version && which shellcheck && shellcheck --version | head -2 && actionlint -color .github/workflows/*.yml; echo exit=$?'
1.7.11
installed by building from source
built with go1.25.7 compiler for linux/amd64
/nix/store/i5kmqg3q40a7n5v0ax06rh22l9qp3xhm-shellcheck-0.11.0-bin/bin/shellcheck
ShellCheck - shell script analysis tool
version: 0.11.0
exit=0
```

- [x] `actionlint --version` reports `1.7.11` (nixpkgs-pinned)
- [x] `shellcheck` resolves to the nix-store version `0.11.0`, on PATH
- [x] `actionlint -color .github/workflows/*.yml` exits 0 across all three files (`ci.yml`, `release-please.yml`, `lint-workflows.yml`)
- [x] New workflow file lints itself clean (recursive sanity)
- [x] Both commits GPG-signed (`152e408`, `2309502`)
- [x] CI: `actionlint` job pass; `build` pass; `instrumented-tests` pass
- [x] Copilot review thread on shellcheck (devenv.nix:39) addressed in commit `2309502`

## Acceptance criteria mapping (#173)

- [x] `pkgs.actionlint` added to `devenv.nix` `packages` list
- [x] `pkgs.actionlint` also added to `flake.nix` `devShells.default.packages` (required for CI's `nix develop` invocation)
- [x] `pkgs.shellcheck` added to both dev shell definitions (needed for actionlint's shellcheck integration; ensures local + CI report identical findings)
- [x] `devenv shell -- actionlint --version` succeeds and reports a non-empty version
- [x] `nix develop --command actionlint --version` succeeds and reports the same version
- [x] New workflow file `.github/workflows/lint-workflows.yml` added; top-level `paths` filter scopes it to `.github/workflows/**`, `devenv.nix`, `devenv.lock`, `flake.nix`, `flake.lock` so it only runs when workflow files or dev-shell composition change
- [x] CI job runs `actionlint` via `nix develop --command actionlint` — same binary as the local dev shell, no marketplace action divergence
- [x] All existing workflow files pass `actionlint` after the change (no regression) — confirmed locally and in CI; pre-requisite SC2129 finding cleared by #174 (`e90152d`)
- [x] PR body documents the chosen install method, the dual dev shell architecture, and the rationale for touching both shell files

## Related

- Refs #173 — this PR
- Refs #174 — pre-requisite (merged in `e90152d`); without it the new workflow would fail CI on day one against `release-please.yml`'s `SC2129` finding
- Unblocks #169 — actionlint is now available for the upcoming 3-workflow refactor

🏴‍☠️ Logged by the Quartermaster. All hands review before we set sail.
