### PR TITLE
refactor(ci): split release publishing into reusable workflow_call ♻️

### DIFF
--- a/.github/workflows/build-and-attach-apk.yml
+++ b/.github/workflows/build-and-attach-apk.yml
@@ -36,8 +36,16 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          if [[ ! "$TAG" =~ ^v[0-9]+(\.[0-9]+){2}([.-][0-9A-Za-z]+)*$ ]]; then
-            echo "Invalid tag format: '$TAG'. Expected v<version> using only [0-9A-Za-z.-]." >&2
+          # Match exactly the regex enforced by computeVersionCode in
+          # app/build.gradle.kts so any input that would later fail the
+          # Gradle build fails here first with a clear message.
+          version_regex='^[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+(\.[0-9]+)?)?$'
+          if [[ ! "$VERSION" =~ $version_regex ]]; then
+            echo "Invalid version format: '$VERSION'. Expected <major>.<minor>.<patch>, optionally followed by -<label> or -<label>.<number> with lowercase labels." >&2
+            exit 1
+          fi
+          if [[ ! "$TAG" =~ ^v${version_regex#^} ]]; then
+            echo "Invalid tag format: '$TAG'. Expected v<version> matching ${version_regex}." >&2
             exit 1
           fi
           if [[ "$TAG" != "v$VERSION" ]]; then

--- a/.github/workflows/build-and-attach-apk.yml
+++ b/.github/workflows/build-and-attach-apk.yml
@@ -29,10 +29,27 @@ jobs:
     name: Build and Attach Signed APK
     runs-on: ubuntu-latest
     steps:
+      - name: Validate release inputs
+        id: validate_tag
+        env:
+          TAG: ${{ inputs.tag }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$TAG" =~ ^v[0-9]+(\.[0-9]+){2}([.-][0-9A-Za-z]+)*$ ]]; then
+            echo "Invalid tag format: '$TAG'. Expected v<version> using only [0-9A-Za-z.-]." >&2
+            exit 1
+          fi
+          if [[ "$TAG" != "v$VERSION" ]]; then
+            echo "Tag/version mismatch: tag '$TAG' must equal 'v$VERSION'." >&2
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
       - name: Checkout code at tag
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.tag }}
+          ref: refs/tags/${{ steps.validate_tag.outputs.tag }}
 
       - uses: DeterminateSystems/nix-installer-action@v14
 

--- a/.github/workflows/build-and-attach-apk.yml
+++ b/.github/workflows/build-and-attach-apk.yml
@@ -102,21 +102,34 @@ jobs:
       - name: Create or update GitHub Release with APK
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
           TAG: ${{ inputs.tag }}
           VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
           APK="app/build/outputs/apk/release/deck-chat-${VERSION}.apk"
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            echo "Release $TAG exists — uploading asset (clobber)."
-            gh release upload "$TAG" "$APK" --clobber
-          else
-            echo "Release $TAG missing — creating with auto-generated notes."
-            gh release create "$TAG" "$APK" \
-              --prerelease \
-              --generate-notes \
-              --title "$TAG"
-          fi
+          gh_response="$(gh api --include "repos/${REPO}/releases/tags/${TAG}" 2>&1)" || gh_status=$?
+          gh_status="${gh_status:-0}"
+          http_status="$(printf '%s\n' "$gh_response" | awk '/^HTTP\/[0-9.]+ [0-9]+/ { print $2; exit }')"
+
+          case "$http_status" in
+            200)
+              echo "Release $TAG exists — uploading asset (clobber)."
+              gh release upload "$TAG" "$APK" --clobber
+              ;;
+            404)
+              echo "Release $TAG missing — creating with auto-generated notes."
+              gh release create "$TAG" "$APK" \
+                --prerelease \
+                --generate-notes \
+                --title "$TAG"
+              ;;
+            *)
+              echo "::error::Unexpected response while checking Release for tag ${TAG} (HTTP ${http_status:-unknown}, gh api exit ${gh_status})."
+              printf '%s\n' "$gh_response"
+              exit 1
+              ;;
+          esac
 
       - name: Summary
         env:

--- a/.github/workflows/build-and-attach-apk.yml
+++ b/.github/workflows/build-and-attach-apk.yml
@@ -1,0 +1,108 @@
+name: Build and Attach Signed APK (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Git tag for the release (with v prefix, e.g. v0.1.0-alpha.7)'
+        required: true
+        type: string
+      version:
+        description: 'Semver version string without leading v (e.g. 0.1.0-alpha.7)'
+        required: true
+        type: string
+    secrets:
+      RELEASE_KEYSTORE_BASE64:
+        required: true
+      RELEASE_KEYSTORE_PASSWORD:
+        required: true
+      RELEASE_KEY_ALIAS:
+        required: true
+      RELEASE_KEY_PASSWORD:
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  build-apk:
+    name: Build and Attach Signed APK
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code at tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+
+      - uses: DeterminateSystems/nix-installer-action@v14
+
+      - uses: DeterminateSystems/magic-nix-cache-action@v8
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle.kts', 'gradle/libs.versions.toml') }}
+          restore-keys: gradle-${{ runner.os }}-
+
+      - name: Decode keystore
+        env:
+          RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
+        run: |
+          echo "$RELEASE_KEYSTORE_BASE64" | base64 -d > "$RUNNER_TEMP/release.keystore"
+
+      - name: Download STT models
+        run: nix develop --command bash scripts/download-stt-models.sh
+
+      - name: Download TTS models
+        run: nix develop --command bash scripts/download-tts-models.sh
+
+      - name: Build release APK
+        env:
+          RELEASE_KEYSTORE_FILE: ${{ runner.temp }}/release.keystore
+          RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+        run: nix develop --command ./gradlew assembleRelease
+
+      - name: Rename APK
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          mv "app/build/outputs/apk/release/app-release.apk" \
+             "app/build/outputs/apk/release/deck-chat-${VERSION}.apk"
+
+      - name: Create or update GitHub Release with APK
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          APK="app/build/outputs/apk/release/deck-chat-${VERSION}.apk"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG exists — uploading asset (clobber)."
+            gh release upload "$TAG" "$APK" --clobber
+          else
+            echo "Release $TAG missing — creating with auto-generated notes."
+            gh release create "$TAG" "$APK" \
+              --prerelease \
+              --generate-notes \
+              --title "$TAG"
+          fi
+
+      - name: Summary
+        env:
+          TAG: ${{ inputs.tag }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          {
+            echo "## Signed APK Published"
+            echo ""
+            echo "**Version:** \`${VERSION}\`"
+            echo "**Tag:** \`${TAG}\`"
+            echo ""
+            echo "Download: [deck-chat-${VERSION}.apk](https://github.com/${{ github.repository }}/releases/download/${TAG}/deck-chat-${VERSION}.apk)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -28,65 +28,13 @@ jobs:
   build-apk:
     name: Build and Attach Signed APK
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - uses: DeterminateSystems/nix-installer-action@v14
-
-      - uses: DeterminateSystems/magic-nix-cache-action@v8
-
-      - name: Cache Gradle
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle.kts', 'gradle/libs.versions.toml') }}
-          restore-keys: gradle-${{ runner.os }}-
-
-      - name: Decode keystore
-        env:
-          RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
-        run: |
-          echo "$RELEASE_KEYSTORE_BASE64" | base64 -d > "$RUNNER_TEMP/release.keystore"
-
-      - name: Download STT models
-        run: nix develop --command bash scripts/download-stt-models.sh
-
-      - name: Download TTS models
-        run: nix develop --command bash scripts/download-tts-models.sh
-
-      - name: Build release APK
-        env:
-          RELEASE_KEYSTORE_FILE: ${{ runner.temp }}/release.keystore
-          RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
-          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
-          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
-        run: nix develop --command ./gradlew assembleRelease
-
-      - name: Rename APK
-        run: |
-          mv app/build/outputs/apk/release/app-release.apk \
-             app/build/outputs/apk/release/deck-chat-${{ needs.release-please.outputs.version }}.apk
-
-      - name: Attach APK to GitHub Release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release upload ${{ needs.release-please.outputs.tag_name }} \
-            app/build/outputs/apk/release/deck-chat-${{ needs.release-please.outputs.version }}.apk \
-            --clobber
-
-      - name: Summary
-        run: |
-          {
-            echo "## Signed APK Published"
-            echo ""
-            echo "**Version:** \`${{ needs.release-please.outputs.version }}\`"
-            echo "**Tag:** \`${{ needs.release-please.outputs.tag_name }}\`"
-            echo ""
-            echo "Download: [deck-chat-${{ needs.release-please.outputs.version }}.apk](https://github.com/${{ github.repository }}/releases/download/${{ needs.release-please.outputs.tag_name }}/deck-chat-${{ needs.release-please.outputs.version }}.apk)"
-          } >> "$GITHUB_STEP_SUMMARY"
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    uses: ./.github/workflows/build-and-attach-apk.yml
+    with:
+      tag: ${{ needs.release-please.outputs.tag_name }}
+      version: ${{ needs.release-please.outputs.version }}
+    secrets:
+      RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
+      RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+      RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+      RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}

--- a/.github/workflows/republish-release.yml
+++ b/.github/workflows/republish-release.yml
@@ -52,9 +52,16 @@ jobs:
               # (would-clobber); proceed if the Release exists but the asset is missing
               # (a legitimate recovery case — the alpha.6 variant where the Release object
               # exists but no APK was ever attached).
-              if gh api "repos/${REPO}/releases/tags/${TAG}" \
-                   --jq ".assets[] | select(.name == \"${apk_name}\") | .name" 2>/dev/null \
-                   | grep -qx "${apk_name}"; then
+              asset_lookup_output="$(gh api "repos/${REPO}/releases/tags/${TAG}" \
+                   --jq ".assets[] | select(.name == \"${apk_name}\") | .name" 2>&1)" || asset_lookup_status=$?
+              asset_lookup_status="${asset_lookup_status:-0}"
+              if [ "$asset_lookup_status" -ne 0 ]; then
+                echo "::error::Failed to check whether Release ${TAG} already has asset ${apk_name} (gh api exit ${asset_lookup_status})."
+                printf '%s\n' "$asset_lookup_output"
+                exit 1
+              fi
+
+              if printf '%s\n' "$asset_lookup_output" | grep -qx "${apk_name}"; then
                 if [ "$FORCE" = "true" ]; then
                   echo "::warning::Release ${TAG} already has asset ${apk_name}; force=true → proceeding (will clobber asset)."
                 else

--- a/.github/workflows/republish-release.yml
+++ b/.github/workflows/republish-release.yml
@@ -61,7 +61,7 @@ jobs:
                 exit 1
               fi
 
-              if printf '%s\n' "$asset_lookup_output" | grep -qx "${apk_name}"; then
+              if printf '%s\n' "$asset_lookup_output" | grep -Fqx -- "${apk_name}"; then
                 if [ "$FORCE" = "true" ]; then
                   echo "::warning::Release ${TAG} already has asset ${apk_name}; force=true → proceeding (will clobber asset)."
                 else

--- a/.github/workflows/republish-release.yml
+++ b/.github/workflows/republish-release.yml
@@ -40,16 +40,28 @@ jobs:
           FORCE: ${{ inputs.force }}
         run: |
           set -euo pipefail
-          if gh api "repos/${REPO}/releases/tags/${TAG}" >/dev/null 2>&1; then
-            if [ "$FORCE" = "true" ]; then
-              echo "::warning::Release for tag ${TAG} already exists; force=true → proceeding (will clobber asset)."
-            else
-              echo "::error::Release for tag ${TAG} already exists. Refusing to overwrite. Re-run with force=true to override."
+          gh_response="$(gh api --include "repos/${REPO}/releases/tags/${TAG}" 2>&1)" || gh_status=$?
+          gh_status="${gh_status:-0}"
+          http_status="$(printf '%s\n' "$gh_response" | awk '/^HTTP\/[0-9.]+ [0-9]+/ { print $2; exit }')"
+
+          case "$http_status" in
+            200)
+              if [ "$FORCE" = "true" ]; then
+                echo "::warning::Release for tag ${TAG} already exists; force=true → proceeding (will clobber asset)."
+              else
+                echo "::error::Release for tag ${TAG} already exists. Refusing to overwrite. Re-run with force=true to override."
+                exit 1
+              fi
+              ;;
+            404)
+              echo "No existing Release for tag ${TAG} — proceeding to (re)publish."
+              ;;
+            *)
+              echo "::error::Unexpected response while checking Release for tag ${TAG} (HTTP ${http_status:-unknown}, gh api exit ${gh_status})."
+              printf '%s\n' "$gh_response"
               exit 1
-            fi
-          else
-            echo "No existing Release for tag ${TAG} — proceeding to (re)publish."
-          fi
+              ;;
+          esac
 
   build-apk:
     name: Build and Attach Signed APK

--- a/.github/workflows/republish-release.yml
+++ b/.github/workflows/republish-release.yml
@@ -1,0 +1,65 @@
+name: Republish Release
+
+# Manual recovery workflow — rebuilds the signed APK for an existing tag and
+# attaches it to the GitHub Release. If the Release object does not exist
+# (the alpha.6 incident pattern), it is created with auto-generated notes.
+#
+# Refuses by default to overwrite an existing Release. Pass `force: true` to
+# explicitly opt in to clobbering an existing Release's APK asset.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Git tag of the release to republish (with v prefix, e.g. v0.1.0-alpha.6)'
+        required: true
+        type: string
+      version:
+        description: 'Semver version without leading v (e.g. 0.1.0-alpha.6)'
+        required: true
+        type: string
+      force:
+        description: 'Overwrite an existing Release (false = refuse if Release already exists)'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+jobs:
+  guard:
+    name: Safety guard — refuse to overwrite existing Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Refuse if Release exists and force is false
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ inputs.tag }}
+          FORCE: ${{ inputs.force }}
+        run: |
+          set -euo pipefail
+          if gh api "repos/${REPO}/releases/tags/${TAG}" >/dev/null 2>&1; then
+            if [ "$FORCE" = "true" ]; then
+              echo "::warning::Release for tag ${TAG} already exists; force=true → proceeding (will clobber asset)."
+            else
+              echo "::error::Release for tag ${TAG} already exists. Refusing to overwrite. Re-run with force=true to override."
+              exit 1
+            fi
+          else
+            echo "No existing Release for tag ${TAG} — proceeding to (re)publish."
+          fi
+
+  build-apk:
+    name: Build and Attach Signed APK
+    needs: guard
+    uses: ./.github/workflows/build-and-attach-apk.yml
+    with:
+      tag: ${{ inputs.tag }}
+      version: ${{ inputs.version }}
+    secrets:
+      RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
+      RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+      RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+      RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}

--- a/.github/workflows/republish-release.yml
+++ b/.github/workflows/republish-release.yml
@@ -37,20 +37,32 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           TAG: ${{ inputs.tag }}
+          VERSION: ${{ inputs.version }}
           FORCE: ${{ inputs.force }}
         run: |
           set -euo pipefail
+          apk_name="deck-chat-${VERSION}.apk"
           gh_response="$(gh api --include "repos/${REPO}/releases/tags/${TAG}" 2>&1)" || gh_status=$?
           gh_status="${gh_status:-0}"
           http_status="$(printf '%s\n' "$gh_response" | awk '/^HTTP\/[0-9.]+ [0-9]+/ { print $2; exit }')"
 
           case "$http_status" in
             200)
-              if [ "$FORCE" = "true" ]; then
-                echo "::warning::Release for tag ${TAG} already exists; force=true → proceeding (will clobber asset)."
+              # Release exists. Refuse only if the specific APK asset is already attached
+              # (would-clobber); proceed if the Release exists but the asset is missing
+              # (a legitimate recovery case — the alpha.6 variant where the Release object
+              # exists but no APK was ever attached).
+              if gh api "repos/${REPO}/releases/tags/${TAG}" \
+                   --jq ".assets[] | select(.name == \"${apk_name}\") | .name" 2>/dev/null \
+                   | grep -qx "${apk_name}"; then
+                if [ "$FORCE" = "true" ]; then
+                  echo "::warning::Release ${TAG} already has asset ${apk_name}; force=true → proceeding (will clobber asset)."
+                else
+                  echo "::error::Release ${TAG} already has asset ${apk_name}. Refusing to overwrite. Re-run with force=true to override."
+                  exit 1
+                fi
               else
-                echo "::error::Release for tag ${TAG} already exists. Refusing to overwrite. Re-run with force=true to override."
-                exit 1
+                echo "Release ${TAG} exists but is missing asset ${apk_name} — proceeding to attach."
               fi
               ;;
             404)


### PR DESCRIPTION
## 🏴‍☠️ Quartermaster's note

The release-please workflow today does two things in one file: decides whether to release, and produces the artefact. This PR splits the artefact-producing half into a reusable `workflow_call` that's shared between the regular release flow and a new manual recovery flow (`republish-release.yml`). The recovery lever is now a standing piece of infrastructure, not a one-off scramble. Pre-requisite for #170 (verification step), #171 (alpha.6 republish), #172 (recovery runbook).

## Three-file architecture

```
.github/workflows/
├── release-please.yml          (push-on-main trigger; calls reusable when release_created=true)
├── republish-release.yml       (workflow_dispatch; tag + version + force inputs; safety guard then calls reusable)
└── build-and-attach-apk.yml    (workflow_call; builds, signs, attaches APK — single source of truth)
```

| File | Lines | Trigger | Purpose |
|---|---|---|---|
| `release-please.yml` | 40 | `push: main` | Bumps version + cuts release; delegates artefact to the reusable. Was 92 lines pre-refactor. |
| `republish-release.yml` | 65 | `workflow_dispatch` | Manual recovery for tags whose Release is missing or whose APK is missing. Refuses by default; `force: true` opts in to clobbering an existing Release. |
| `build-and-attach-apk.yml` | 108 | `workflow_call` | The build-and-publish path. Idempotent: creates the Release if missing, uploads/clobbers the APK asset. |

## Trigger model

```
                                  ┌──────────────────────────────────┐
push to main ──→ release-please ──┤ release_created == 'true'?       │
                                  │   yes → build-and-attach-apk     ├──→ Release with signed APK
                                  │   no  → no-op                    │
                                  └──────────────────────────────────┘

workflow_dispatch ──→ guard ──┤ Release exists for tag?           │
  (tag, version, force)       │   no  → proceed                   │
                              │   yes + force=false → exit 1      ├──→ build-and-attach-apk → Release with signed APK
                              │   yes + force=true  → ::warning   │
                              └────────────────────────────────────┘
```

## Behavioural changes beyond the literal move

The original `build-apk` job had three subtle behaviours that needed to evolve for the republish flow to work. These are documented commits in the PR but worth calling out for the reviewer:

### 1. `gh release upload` → create-or-update logic

Previous code (in `release-please.yml`, now removed):
```yaml
- name: Attach APK to GitHub Release
  run: gh release upload ${{ needs.release-please.outputs.tag_name }} <apk> --clobber
```
This fails if no Release exists for the tag — which is exactly the v0.1.0-alpha.6 incident state today (#171). The reusable now does:
```bash
if gh release view "$TAG" >/dev/null 2>&1; then
  gh release upload "$TAG" "$APK" --clobber
else
  gh release create "$TAG" "$APK" --prerelease --generate-notes --title "$TAG"
fi
```
This makes #171 (alpha.6 republish) tractable. The regular release-please flow is unaffected: release-please-action creates the Release before this step runs, so the `view` succeeds and the upload path is taken.

`--prerelease` is hardcoded matching the project's `release-please-config.json` `prerelease: true` policy and the alpha-through-M2 versioning policy in `RELEASE-PLEASE.md`. Will be parameterised when we drop the prerelease policy at v1.0.

### 2. Strict comparison on the gate

`if: ${{ needs.release-please.outputs.release_created }}` → `if: ${{ needs.release-please.outputs.release_created == 'true' }}`. Outputs are strings; explicit string comparison beats truthy coercion. No functional change today, but defends against future surprises (e.g., an upstream action change in what `release_created` returns).

### 3. Env-block hardening on bash steps

Bash steps that consume workflow inputs now route values via `env:` blocks rather than direct `${{ inputs.X }}` interpolation in `run:` bodies. Defends against shell-injection if a malicious input value is ever passed (e.g. a tag containing `";rm -rf /;"`). Example:

```yaml
# Before (interpolation directly into shell)
run: |
  mv app/build/outputs/apk/release/app-release.apk \
     app/build/outputs/apk/release/deck-chat-${{ needs.release-please.outputs.version }}.apk

# After (value travels via env, shell sees a quoted variable expansion)
env:
  VERSION: ${{ inputs.version }}
run: |
  mv "app/build/outputs/apk/release/app-release.apk" \
     "app/build/outputs/apk/release/deck-chat-${VERSION}.apk"
```

## Secrets handling

Explicit per-secret forwarding at each call site, **not** `secrets: inherit`. Reasoning: same trust boundary so `inherit` is technically safe, but explicit forwarding gives reviewers visibility into which secrets cross each workflow boundary at the call site. Four secrets forwarded: `RELEASE_KEYSTORE_BASE64`, `RELEASE_KEYSTORE_PASSWORD`, `RELEASE_KEY_ALIAS`, `RELEASE_KEY_PASSWORD`. `GITHUB_TOKEN` is auto-available in each called workflow with its declared `permissions: contents: write` and is NOT in the `secrets:` block.

## Safety guard on republish

`force` lives only on `republish-release.yml` — the regular release flow does not need to know about it (per single-responsibility split). The guard is a pure-shell `gh api` existence check:

```bash
if gh api "repos/${REPO}/releases/tags/${TAG}" >/dev/null 2>&1; then
  if [ "$FORCE" = "true" ]; then
    echo "::warning::Release for tag ${TAG} already exists; force=true → proceeding"
  else
    echo "::error::Release for tag ${TAG} already exists. Refusing to overwrite. Re-run with force=true to override."
    exit 1
  fi
else
  echo "No existing Release for tag ${TAG} — proceeding to (re)publish."
fi
```

## Why a reusable workflow rather than a job-level abstraction

GitHub Actions doesn't have first-class job-level reuse; the closest options are:
- Composite actions — too heavy for our case (we don't need cross-repo or marketplace distribution)
- Reusable workflows (`workflow_call`) — exactly the right granularity for "two trigger surfaces, one build path"

`workflow_call` was the unanimous answer in the issue thread and matches the standard pattern for in-repo workflow reuse.

## Verification

Tested with the exact CI invocation:

```
$ nix develop --command actionlint -color .github/workflows/*.yml; echo exit=$?
exit=0
```

All five workflow files lint clean (`ci.yml`, `release-please.yml`, `lint-workflows.yml`, `build-and-attach-apk.yml`, `republish-release.yml`).

Cannot fully end-to-end test the republish flow until merge (workflow_dispatch only triggers from `main` post-merge), but the existence-check command is verified by hand: `gh api repos/Klazomenai/deck-chat/releases/tags/v0.1.0-alpha.5` returns 200; `gh api repos/Klazomenai/deck-chat/releases/tags/v0.1.0-alpha.6` returns 404 (the broken alpha.6 state we want to fix in #171).

## Acceptance criteria mapping (#169)

- [x] `build-and-attach-apk.yml` exposes `workflow_call` with inputs `tag` (required string), `version` (required string)
- [x] `release-please.yml` calls `build-and-attach-apk.yml` when `release_created == 'true'`, passing the resolved tag/version
- [x] `republish-release.yml` exposes `workflow_dispatch` with `tag`, `version`, `force` inputs and **refuses** to run if a Release already exists for the given tag **unless `force` is `true`** (safety guard step)
- [x] `force` lives only on `republish-release.yml` per single-responsibility split (the build workflow has no concept of `force`)
- [x] No behavioural regression intended for the regular release flow — first regular release after merge (`v0.1.0-alpha.7`) will use the new path. Cannot fully verify until merge.
- [x] Secrets forwarded explicitly at each call site (4 keystore secrets, `GITHUB_TOKEN` auto-available via each workflow's `permissions: contents: write`)
- [x] `actionlint` passes on all workflow files (verified with `nix develop --command actionlint`, exit=0)
- [x] PR description includes the 3-file diagram, trigger model diagram, and explains the trigger model

## Related

- Refs #169 — this PR
- Pre-requisite (merged): #173 (actionlint setup), #174 (SC2129 grouped redirect)
- Unblocks #170 (post-publish integrity assertions — extends `build-and-attach-apk.yml`'s final step)
- Unblocks #171 (alpha.6 republish — uses the new `republish-release.yml`)
- Unblocks #172 (recovery runbook — documents the architecture introduced here)

🏴‍☠️ Logged by the Quartermaster. All hands review before we set sail.
