### PR TITLE
feat(ci): assert release artifact integrity post-publish ✨

### DIFF
--- a/.github/workflows/build-and-attach-apk.yml
+++ b/.github/workflows/build-and-attach-apk.yml
@@ -131,6 +131,57 @@ jobs:
               ;;
           esac
 
+      - name: Verify Release artifact integrity
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ inputs.tag }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          apk_name="deck-chat-${VERSION}.apk"
+
+          # Assertion 1: Release exists for the tag.
+          # We just created or upload-clobbered the Release, so a non-zero exit
+          # from `gh api` here indicates a real problem (transient API failure,
+          # permission regression, or the upstream create/upload silently failed).
+          release_json="$(gh api "repos/${REPO}/releases/tags/${TAG}" 2>&1)" || api_status=$?
+          api_status="${api_status:-0}"
+          if [ "$api_status" -ne 0 ]; then
+            echo "::error::Assertion 1 failed (Release exists): could not query Release ${TAG} (gh api exit ${api_status})."
+            printf '%s\n' "$release_json"
+            exit 1
+          fi
+
+          # Assertion 2: prerelease == true.
+          # Matches release-please-config.json `prerelease: true` and the
+          # alpha-through-M2 versioning policy in RELEASE-PLEASE.md.
+          prerelease="$(printf '%s' "$release_json" | jq -r '.prerelease')"
+          if [ "$prerelease" != "true" ]; then
+            echo "::error::Assertion 2 failed (prerelease flag): Release ${TAG} prerelease=${prerelease}, expected true."
+            exit 1
+          fi
+
+          # Assertion 3: APK asset attached.
+          # Empty `asset_size` from jq indicates "no asset of that name" (jq
+          # returns no output when the filter matches nothing); explicit
+          # empty-string check disambiguates this from `0` (zero bytes).
+          asset_size="$(printf '%s' "$release_json" | jq -r --arg name "${apk_name}" '.assets[] | select(.name == $name) | .size')"
+          if [ -z "$asset_size" ]; then
+            echo "::error::Assertion 3 failed (APK asset attached): Release ${TAG} is missing asset ${apk_name}."
+            echo "Attached assets:"
+            printf '%s' "$release_json" | jq -r '.assets[].name' | sed 's/^/  - /'
+            exit 1
+          fi
+
+          # Assertion 4: asset size > 0.
+          if [ "$asset_size" = "0" ]; then
+            echo "::error::Assertion 4 failed (asset size > 0): Release ${TAG} asset ${apk_name} has zero size."
+            exit 1
+          fi
+
+          echo "Release ${TAG} integrity verified: prerelease=true, ${apk_name} attached (size=${asset_size} bytes)."
+
       - name: Summary
         env:
           TAG: ${{ inputs.tag }}


### PR DESCRIPTION
## 🏴‍☠️ Quartermaster's note

Trust, but inspect the cargo before logging it. Adds four post-publish assertions to the reusable build workflow so silent skips like the v0.1.0-alpha.6 incident — release-please reported success while build-apk silently failed and no APK was ever attached — become loud test failures on the day of the incident. The four assertions gate every Release this project publishes (both regular release-please flow and manual republish flow).

## What changed

One new step at the end of `.github/workflows/build-and-attach-apk.yml`:

```yaml
- name: Verify Release artifact integrity
  env:
    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
    REPO: ${{ github.repository }}
    TAG: ${{ inputs.tag }}
    VERSION: ${{ inputs.version }}
  run: |
    set -euo pipefail
    apk_name="deck-chat-${VERSION}.apk"
    # ... 4 assertions, see commit body for full text ...
```

Step ordering in the reusable is now:
```
Validate release inputs
  → Checkout code at tag (refs/tags/<tag>)
  → Cache Gradle / Decode keystore / Download STT/TTS models
  → Build release APK
  → Rename APK
  → Create or update GitHub Release with APK
  → Verify Release artifact integrity   ← NEW
  → Summary
```

The verification step runs **after** the create-or-update step and **before** Summary, so the Summary message ("Signed APK Published") only appears in the run summary when the artefact is verified intact.

## The four assertions

| # | Asserts | Failure mode it catches |
|---|---|---|
| 1 | Release exists for the tag | Upstream `gh release create` or `gh release upload --clobber` silently failed; transient API error; permission regression |
| 2 | `prerelease == true` | Future regression where the policy changes accidentally; matches `release-please-config.json` `prerelease: true` |
| 3 | Asset `deck-chat-<version>.apk` attached | Build succeeded but upload silently failed; asset stored under wrong name |
| 4 | Asset size > 0 | Truncated upload (network blip mid-stream) |

Each failure exits 1 with a **named** error message (e.g. `::error::Assertion 3 failed (APK asset attached): Release v0.1.0-alpha.7 is missing asset deck-chat-0.1.0-alpha.7.apk.`), not just "exit 1" — so the GitHub Actions UI's failure annotation tells you exactly which check failed.

## Why this lives in the reusable, not in callers

Both `release-please.yml` and `republish-release.yml` now run the same verification gate. Putting it in the called workflow rather than each caller:

- Single source of truth for what "valid release" means
- Future call sites (e.g., a hypothetical hotfix workflow) inherit the gate by default
- Matches the AC: "Step executes for both callers (lives in the reusable workflow, not in a caller)"

## Why each assertion uses a separate `if` block, not a chained command

Symmetry with the established fail-closed `gh api` pattern (commits `7f82416`, `ecdc8bd`, `ce8b6e4` from #169 review). Each assertion identifies itself in the failure message; chaining would lose that specificity.

## Why empty-string check on `asset_size`

`jq` outputs nothing when the filter matches no element — distinct from outputting `0` for an asset with zero bytes. The two failure modes are functionally different (asset missing entirely vs asset present but empty), and the assertions report them as Assertion 3 vs Assertion 4 respectively.

## Verification

Manually validated the assertion logic against the real published alpha.5 release before pushing:

```
$ release_json="$(gh api repos/Klazomenai/deck-chat/releases/tags/v0.1.0-alpha.5)"
$ echo "$release_json" | jq -r '.prerelease'
true                                                          ← Assertion 2 passes

$ echo "$release_json" | jq -r --arg name "deck-chat-0.1.0-alpha.5.apk" \
    '.assets[] | select(.name == $name) | .size'
604950848                                                     ← Assertion 3 + 4 pass

$ echo "$release_json" | jq -r --arg name "nonexistent.apk" \
    '.assets[] | select(.name == $name) | .size'
                                                              ← Empty output for missing asset (Assertion 3 would fail with named message)
```

`actionlint` clean across all five workflow files: `nix develop --command actionlint -color .github/workflows/*.yml` exits 0.

## End-to-end verification path

This PR cannot be fully end-to-end tested until merge (the workflow only runs on push-to-main from release-please's flow, or via workflow_dispatch). Two real-world tests will follow:

1. The next regular release (alpha.7 via release-please PR #139) will exercise the assertion against the regular flow's outputs (200 → upload-clobber → verify).
2. **#171** (alpha.6 republish) will exercise the assertion against the recovery flow's outputs (404 → create → verify) — the verification step IS the verification of #171's success.

## Acceptance criteria mapping (#170)

- [x] Verification step runs as the final step of `build-and-attach-apk.yml` (after Create/Update, before Summary)
- [x] All four assertions enforced (Release exists, `prerelease=true`, APK asset present, non-zero size)
- [x] Step uses `gh api` (GitHub CLI) not raw `curl`
- [x] Failure messages name the missing/wrong field, not just "exit 1" — each `echo "::error::Assertion N failed (..."`
- [x] Step executes for both `release-please.yml` and `republish-release.yml` callers (lives in the reusable workflow, not in a caller)

## Related

- Refs #170 — this PR
- Pre-requisite (merged): #169 (3-workflow reusable architecture; this assertion lives in the reusable)
- Unblocks #171 (alpha.6 republish — uses the new assertions to validate the result)
- Unblocks #172 (recovery runbook — assertion failure messages will be referenced as observable signals in the runbook)
- Side-note: M2 #178 (extract fail-closed `gh api` status-case as shared helper) — this PR adds a fourth occurrence of the pattern; #178 is the planned cleanup

🏴‍☠️ Logged by the Quartermaster. All hands review before we set sail.
