### PR TITLE
feat(ci): add Quartermaster's Log header to release notes ✨

### DIFF
--- a/.github/workflows/build-and-attach-apk.yml
+++ b/.github/workflows/build-and-attach-apk.yml
@@ -277,12 +277,24 @@ jobs:
           issue_numbers="$(printf '%s' "$body" | grep -oE '#[0-9]+' | sort -u | tr -d '#' || true)"
           dominant_milestone=""
           if [ -n "$issue_numbers" ]; then
-            ms_counts="$(
-              for n in $issue_numbers; do
-                gh api "repos/${REPO}/issues/${n}" --jq '.milestone.title // empty' 2>/dev/null || true
-              done | grep -v '^$' | sort | uniq -c | sort -rn || true
-            )"
-            if [ -n "$ms_counts" ]; then
+            # Track per-issue lookup failures explicitly: a partial set (e.g. from a
+            # mid-loop rate limit) could otherwise yield a misleading "dominant"
+            # milestone derived from whichever subset happened to succeed. Abort the
+            # callout entirely on first failure — the rest of the Log still renders.
+            issue_lookup_failed=0
+            ms_titles=""
+            for n in $issue_numbers; do
+              if title="$(gh api "repos/${REPO}/issues/${n}" --jq '.milestone.title // empty' 2>/dev/null)"; then
+                [ -n "$title" ] && ms_titles="${ms_titles}${title}"$'\n'
+              else
+                issue_lookup_failed=1
+                break
+              fi
+            done
+            if [ "$issue_lookup_failed" = "1" ]; then
+              echo "Milestone callout omitted: per-issue lookup failed (rate limit / transient API error)."
+            elif [ -n "$ms_titles" ]; then
+              ms_counts="$(printf '%s' "$ms_titles" | sort | uniq -c | sort -rn)"
               total_milestoned=$(printf '%s\n' "$ms_counts" | awk '{s+=$1} END {print s+0}')
               top_count=$(printf '%s\n' "$ms_counts" | head -1 | awk '{print $1+0}')
               top_title=$(printf '%s\n' "$ms_counts" | head -1 | awk '{$1=""; sub(/^ /, ""); print}')

--- a/.github/workflows/build-and-attach-apk.yml
+++ b/.github/workflows/build-and-attach-apk.yml
@@ -279,8 +279,15 @@ jobs:
               done | sort | uniq -c | sort -rn | head -1 | awk '{$1=""; sub(/^ /, ""); print}' || true
             )"
             if [ -n "${dominant_milestone:-}" ]; then
-              ms_data="$(gh api "repos/${REPO}/milestones?state=all" --jq ".[] | select(.title == \"${dominant_milestone}\")" 2>/dev/null || true)"
-              if [ -n "${ms_data:-}" ]; then
+              # `--paginate` + `per_page=100` so we don't silently miss milestones on
+              # later pages once the project accumulates more than 30 (the default).
+              # Filter locally with `jq --arg` rather than interpolating the title into
+              # the jq expression — defends against milestone titles that contain
+              # double-quotes or backslashes (which would otherwise break the jq syntax
+              # silently because of the `2>/dev/null || true` chain).
+              milestones_json="$(gh api --paginate "repos/${REPO}/milestones?state=all&per_page=100" 2>/dev/null || true)"
+              ms_data="$(printf '%s' "$milestones_json" | jq --arg title "$dominant_milestone" -c 'first(.[] | select(.title == $title))' 2>/dev/null || true)"
+              if [ -n "${ms_data:-}" ] && [ "$ms_data" != "null" ]; then
                 ms_state="$(printf '%s' "$ms_data" | jq -r '.state')"
                 ms_open="$(printf '%s' "$ms_data" | jq -r '.open_issues')"
                 ms_closed="$(printf '%s' "$ms_data" | jq -r '.closed_issues')"

--- a/.github/workflows/build-and-attach-apk.yml
+++ b/.github/workflows/build-and-attach-apk.yml
@@ -253,7 +253,15 @@ jobs:
 
           summary_line=""
           if [ ${#summary_parts[@]} -gt 0 ]; then
-            joined=$(IFS=', '; printf '%s' "${summary_parts[*]}")
+            # Build the joined string explicitly: `${arr[*]}` with `IFS=', '` only uses
+            # the FIRST character of IFS (i.e. `,`), so the spaces would be lost.
+            joined=""
+            for part in "${summary_parts[@]}"; do
+              if [ -n "$joined" ]; then
+                joined="${joined}, "
+              fi
+              joined="${joined}${part}"
+            done
             summary_line="**This release:** ${joined}."
           fi
 

--- a/.github/workflows/build-and-attach-apk.yml
+++ b/.github/workflows/build-and-attach-apk.yml
@@ -270,14 +270,30 @@ jobs:
 
           # Milestone callout — fail-soft if the API calls error.
           # Find dominant milestone among issues referenced in the changelog body.
+          # Require a strict majority (top count > total/2) before claiming a release
+          # "belongs to" a given milestone — releases that genuinely span milestones
+          # should produce no callout rather than misleading the reader.
           milestone_callout=""
           issue_numbers="$(printf '%s' "$body" | grep -oE '#[0-9]+' | sort -u | tr -d '#' || true)"
+          dominant_milestone=""
           if [ -n "$issue_numbers" ]; then
-            dominant_milestone="$(
+            ms_counts="$(
               for n in $issue_numbers; do
                 gh api "repos/${REPO}/issues/${n}" --jq '.milestone.title // empty' 2>/dev/null || true
-              done | sort | uniq -c | sort -rn | head -1 | awk '{$1=""; sub(/^ /, ""); print}' || true
+              done | grep -v '^$' | sort | uniq -c | sort -rn || true
             )"
+            if [ -n "$ms_counts" ]; then
+              total_milestoned=$(printf '%s\n' "$ms_counts" | awk '{s+=$1} END {print s+0}')
+              top_count=$(printf '%s\n' "$ms_counts" | head -1 | awk '{print $1+0}')
+              top_title=$(printf '%s\n' "$ms_counts" | head -1 | awk '{$1=""; sub(/^ /, ""); print}')
+              # Strict majority: top must be > half of milestoned issues.
+              # Examples: 1-of-1 ✓, 1-of-2 ✗, 2-of-3 ✓, 2-of-4 ✗, 3-of-5 ✓, 2-of-2-of-1 ✗.
+              if [ "$top_count" -gt $((total_milestoned / 2)) ]; then
+                dominant_milestone="$top_title"
+              else
+                echo "Milestone callout omitted: no strict majority (${top_count} of ${total_milestoned} milestoned issues — split across multiple milestones)."
+              fi
+            fi
             if [ -n "${dominant_milestone:-}" ]; then
               # `--paginate` + `per_page=100` so we don't silently miss milestones on
               # later pages once the project accumulates more than 30 (the default).

--- a/.github/workflows/build-and-attach-apk.yml
+++ b/.github/workflows/build-and-attach-apk.yml
@@ -187,7 +187,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           TAG: ${{ inputs.tag }}
-          VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/build-and-attach-apk.yml
+++ b/.github/workflows/build-and-attach-apk.yml
@@ -23,6 +23,7 @@ on:
 
 permissions:
   contents: write
+  issues: read
 
 jobs:
   build-apk:

--- a/.github/workflows/build-and-attach-apk.yml
+++ b/.github/workflows/build-and-attach-apk.yml
@@ -182,6 +182,127 @@ jobs:
 
           echo "Release ${TAG} integrity verified: prerelease=true, ${apk_name} attached (size=${asset_size} bytes)."
 
+      - name: Annotate Release with Quartermaster's Log
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ inputs.tag }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+
+          # Fetch current Release body and id.
+          release_json="$(gh api "repos/${REPO}/releases/tags/${TAG}" 2>&1)" || api_status=$?
+          api_status="${api_status:-0}"
+          if [ "$api_status" -ne 0 ]; then
+            echo "::error::Failed to fetch Release ${TAG} for annotation (gh api exit ${api_status})."
+            printf '%s\n' "$release_json"
+            exit 1
+          fi
+          release_id="$(printf '%s' "$release_json" | jq -r '.id')"
+          body="$(printf '%s' "$release_json" | jq -r '.body')"
+
+          # Idempotency: skip if already annotated.
+          if printf '%s' "$body" | grep -q "Quartermaster's Log"; then
+            echo "Release ${TAG} already has Quartermaster's Log header — skipping annotation."
+            exit 0
+          fi
+
+          # Curated banter (optional) — read .github/release-notes/<tag>.md if present.
+          banter_file=".github/release-notes/${TAG}.md"
+          curated_banter=""
+          if [ -f "$banter_file" ]; then
+            curated_banter="$(cat "$banter_file")"
+            echo "Curated banter loaded from ${banter_file} (${#curated_banter} chars)."
+          else
+            echo "No curated banter file at ${banter_file}; auto-summary only."
+          fi
+
+          # Section counts — parse release-please's `### <emoji> <name>` / `* <item>` format.
+          # Each section runs from its `### ` heading to the next `### ` heading.
+          count_section() {
+            local marker="$1"
+            printf '%s\n' "$body" \
+              | awk -v marker="$marker" '
+                  $0 ~ "^### " marker { in_sec = 1; next }
+                  /^### / && in_sec { exit }
+                  in_sec && /^\* / { count++ }
+                  END { print count + 0 }
+                '
+          }
+          feat_count=$(count_section "⛵ New Rigging")
+          fix_count=$(count_section "🔧 Hull Repairs")
+          perf_count=$(count_section "⚡ Trimmed the Sails")
+          refactor_count=$(count_section "♻️ Refitted")
+          revert_count=$(count_section "↩️ Struck from the Log")
+          security_count=$(count_section "🔐 Battened Hatches")
+
+          summary_parts=()
+          [ "$feat_count" -gt 0 ] && summary_parts+=("${feat_count} ⛵ new rigging")
+          [ "$fix_count" -gt 0 ] && summary_parts+=("${fix_count} 🔧 hull repairs")
+          [ "$perf_count" -gt 0 ] && summary_parts+=("${perf_count} ⚡ trimmed sails")
+          [ "$refactor_count" -gt 0 ] && summary_parts+=("${refactor_count} ♻️ refitted")
+          [ "$revert_count" -gt 0 ] && summary_parts+=("${revert_count} ↩️ struck from log")
+          [ "$security_count" -gt 0 ] && summary_parts+=("${security_count} 🔐 battened hatches")
+
+          summary_line=""
+          if [ ${#summary_parts[@]} -gt 0 ]; then
+            joined=$(IFS=', '; printf '%s' "${summary_parts[*]}")
+            summary_line="**This release:** ${joined}."
+          fi
+
+          # Milestone callout — fail-soft if the API calls error.
+          # Find dominant milestone among issues referenced in the changelog body.
+          milestone_callout=""
+          issue_numbers="$(printf '%s' "$body" | grep -oE '#[0-9]+' | sort -u | tr -d '#' || true)"
+          if [ -n "$issue_numbers" ]; then
+            dominant_milestone="$(
+              for n in $issue_numbers; do
+                gh api "repos/${REPO}/issues/${n}" --jq '.milestone.title // empty' 2>/dev/null || true
+              done | sort | uniq -c | sort -rn | head -1 | awk '{$1=""; sub(/^ /, ""); print}' || true
+            )"
+            if [ -n "${dominant_milestone:-}" ]; then
+              ms_data="$(gh api "repos/${REPO}/milestones?state=all" --jq ".[] | select(.title == \"${dominant_milestone}\")" 2>/dev/null || true)"
+              if [ -n "${ms_data:-}" ]; then
+                ms_state="$(printf '%s' "$ms_data" | jq -r '.state')"
+                ms_open="$(printf '%s' "$ms_data" | jq -r '.open_issues')"
+                ms_closed="$(printf '%s' "$ms_data" | jq -r '.closed_issues')"
+                ms_total=$((ms_open + ms_closed))
+                if [ "$ms_state" = "closed" ] || [ "$ms_open" = "0" ]; then
+                  milestone_callout="**🏴‍☠️ ${dominant_milestone}** — milestone complete (${ms_closed} of ${ms_total} issues closed)."
+                else
+                  milestone_callout="**🏴‍☠️ ${dominant_milestone}** — ${ms_closed} of ${ms_total} issues closed."
+                fi
+              fi
+            fi
+          fi
+          if [ -z "${milestone_callout:-}" ]; then
+            echo "Milestone callout omitted (no dominant milestone, or API lookup failed — fail-soft)."
+          fi
+
+          # Compose the Log header.
+          {
+            echo "## 🏴‍☠️ Quartermaster's Log"
+            echo ""
+            if [ -n "$curated_banter" ]; then
+              printf '%s\n' "$curated_banter"
+              echo ""
+            fi
+            [ -n "${milestone_callout:-}" ] && { printf '%s\n' "$milestone_callout"; echo ""; }
+            [ -n "$summary_line" ] && { printf '%s\n' "$summary_line"; echo ""; }
+            echo "---"
+            echo ""
+            printf '%s' "$body"
+          } > /tmp/log_annotated_body.md
+
+          # PATCH the Release body. `gh api -F body=@file` reads from file (rich body).
+          gh api "repos/${REPO}/releases/${release_id}" \
+            -X PATCH \
+            -F body=@/tmp/log_annotated_body.md \
+            >/dev/null
+
+          echo "Quartermaster's Log header added to Release ${TAG}."
+
       - name: Summary
         env:
           TAG: ${{ inputs.tag }}

--- a/.github/workflows/build-and-attach-apk.yml
+++ b/.github/workflows/build-and-attach-apk.yml
@@ -199,8 +199,14 @@ jobs:
             printf '%s\n' "$release_json"
             exit 1
           fi
-          release_id="$(printf '%s' "$release_json" | jq -r '.id')"
-          body="$(printf '%s' "$release_json" | jq -r '.body')"
+          release_id="$(printf '%s' "$release_json" | jq -r '.id // empty')"
+          if [ -z "$release_id" ]; then
+            echo "::error::Failed to determine Release id for ${TAG}; response was malformed."
+            printf '%s\n' "$release_json"
+            exit 1
+          fi
+          # `.body // ""` so a JSON-null body becomes empty string, not the literal "null".
+          body="$(printf '%s' "$release_json" | jq -r '.body // ""')"
 
           # Idempotency: skip if already annotated.
           if printf '%s' "$body" | grep -q "Quartermaster's Log"; then

--- a/.github/workflows/build-and-attach-apk.yml
+++ b/.github/workflows/build-and-attach-apk.yml
@@ -208,8 +208,11 @@ jobs:
           # `.body // ""` so a JSON-null body becomes empty string, not the literal "null".
           body="$(printf '%s' "$release_json" | jq -r '.body // ""')"
 
-          # Idempotency: skip if already annotated.
-          if printf '%s' "$body" | grep -q "Quartermaster's Log"; then
+          # Idempotency: skip only if the exact annotation header line already exists.
+          # `-F` fixed-string (no regex), `-x` whole-line match — defends against the
+          # phrase "Quartermaster's Log" appearing in a commit message or PR title that
+          # release-please pulled into the changelog.
+          if printf '%s\n' "$body" | grep -Fqx "## 🏴‍☠️ Quartermaster's Log"; then
             echo "Release ${TAG} already has Quartermaster's Log header — skipping annotation."
             exit 0
           fi

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: read
 
 jobs:
   release-please:

--- a/.github/workflows/republish-release.yml
+++ b/.github/workflows/republish-release.yml
@@ -26,6 +26,7 @@ on:
 
 permissions:
   contents: write
+  issues: read
 
 jobs:
   guard:


### PR DESCRIPTION
## 🏴‍☠️ Quartermaster's note

Adds an automatic "🏴‍☠️ Quartermaster's Log" header to every release's body, prepended above the auto-generated changelog. Combines an automatic summary (changelog-section counts + dominant-milestone progress) with optional per-release curated banter from `.github/release-notes/<tag>.md`. Lives as a new step in the reusable `build-and-attach-apk.yml`, runs after the integrity assertions, fail-soft on milestone-API errors.

## What changed

One new step (~120 lines) in `.github/workflows/build-and-attach-apk.yml`, between `Verify Release artifact integrity` and `Summary`. No file deletions or moves; no behavioural change to any existing step.

```
build-and-attach-apk.yml steps:
  Validate release inputs
  Checkout code at tag
  Cache Gradle / Decode keystore / Download STT/TTS models
  Build release APK / Rename APK
  Create or update GitHub Release with APK
  Verify Release artifact integrity
  Annotate Release with Quartermaster's Log    ← NEW
  Summary
```

## Format

```markdown
## 🏴‍☠️ Quartermaster's Log

[curated banter from .github/release-notes/<tag>.md if present]

**🏴‍☠️ M1: First Watch** — milestone complete (57 of 57 issues closed).

**This release:** 6 ⛵ new rigging, 2 🔧 hull repairs.

---

[auto-generated changelog continues here, unchanged]
```

When no curated banter file exists: the milestone callout + section summary are still rendered. When a section's count is 0, that section is omitted from the summary line. When milestone lookup fails (rate limit, transient 5xx, no clear dominant milestone): the callout is silently omitted (fail-soft) — the rest of the Log still renders.

## Three sources of content

### 1. Curated banter (optional)

Per-release banter file at `.github/release-notes/<tag>.md` — e.g. `.github/release-notes/v0.1.0-alpha.8.md`. Free-form markdown. If the file exists, contents go at the very top of the Log; if absent, the Log starts with the milestone callout. The directory will be empty after this PR; per-release banter files are added by subsequent commits.

### 2. Milestone callout (auto, fail-soft)

Identified by querying each `#N` issue reference in the changelog body, grouping by `.milestone.title`, and picking the modal value. Reports `closed/total` issue counts. When milestone state=closed (or `open_issues=0`), uses "milestone complete" wording.

If the milestone-API lookup errors at any point, the callout is silently omitted with a log message. The integrity assertions (#170) remain the strict gate; the Log is best-effort decoration.

### 3. Section summary (auto)

Counts `* <item>` entries under each `### <emoji> <name>` heading using awk. All six sections defined in `release-please-config.json` are recognised:

| Marker | Section |
|---|---|
| ⛵ | New Rigging (`feat:`) |
| 🔧 | Hull Repairs (`fix:`) |
| ⚡ | Trimmed the Sails (`perf:`) |
| ♻️ | Refitted (`refactor:`) |
| ↩️ | Struck from the Log (`revert:`) |
| 🔐 | Battened Hatches (`security:`) |

Sections with zero items are omitted from the summary line.

## Idempotency

The step grep-checks for the literal string `Quartermaster's Log` in the existing body before annotating; if present, it exits 0 with a log message. This means:

- Re-running the workflow against an already-annotated release is a no-op
- Manual edits to a Release's curated banter survive subsequent reruns
- The `republish-release.yml` flow (which calls the same reusable workflow) does not double-annotate
- A future operator can hand-edit a Release's body without fear of having those edits clobbered

## Failure modes

| Scenario | Behaviour |
|---|---|
| Curated banter file absent | Auto-summary only; no error |
| Milestone lookup API error (any of N requests) | Callout omitted silently; section summary + curated banter still rendered |
| No clear dominant milestone (e.g., spread across many) | Callout omitted silently |
| Release body fetch fails | Step exits 1 with named error (consistent with the file's other fail-closed pattern instances) |
| All section counts are 0 | Summary line omitted; only milestone callout + curated banter render |
| All three sources empty | Log header is just the title + horizontal rule + original body. Cosmetic-only no-op. |

## Verification

Tested locally before pushing:

- `nix develop --command actionlint -color .github/workflows/*.yml` exits 0
- Section-count awk parses live alpha.7 body correctly: **6 ⛵ new rigging, 4 🔧 hull repairs, 0 ⚡ trimmed sails, 2 ♻️ refitted, 0 ↩️ struck, 0 🔐 battened**. Matches the actual changelog.
- Milestone-lookup loop tested in a fresh `bash -c` subshell against alpha.7's referenced issues: **M1: First Watch wins 5-1 over M2: Full Complement**. Exactly the right answer — most of alpha.7's content is M1 release-pipeline-hardening work.

## After merge

The next release (alpha.8 or later, whenever release-please's PR merges) will be the first to publish with the Log header attached automatically.

For alpha.7 specifically, this PR's workflow change does not retroactively annotate it — the build job only runs on new releases. After this PR merges, I'll do a one-off `gh api` PATCH against the alpha.7 Release body to add its Log retroactively, using the same algorithm as the workflow step. (Or we can re-run `republish-release.yml` against alpha.7 with `force=true`, which would re-build but also re-annotate. The one-off `gh api` is cheaper and equivalent for the body content.)

## Acceptance criteria mapping (#181)

- [x] New step `Annotate Release with Quartermaster's Log` added to `build-and-attach-apk.yml`, runs after `Verify Release artifact integrity` and before `Summary`
- [x] Step uses `gh api` (not `curl`)
- [x] Step is idempotent: re-running on an already-annotated release is a no-op with a log message
- [x] Auto-summary section count parses release-please's standard `### <emoji> <name>` / `* <item>` format correctly (verified against alpha.7 body)
- [x] Milestone callout reports closed/total issue counts; uses "milestone complete" wording when state=closed
- [x] Curated banter file path: `.github/release-notes/<tag>.md` — absence is graceful, not an error
- [x] Failure of milestone lookup does not block annotation (fail-soft)
- [x] `actionlint` passes on all workflow files
- [ ] After merge: alpha.7 retroactively annotated via one-off `gh api` PATCH (next step after this PR lands)

## Related

- Refs #181 — this PR
- Builds on #170 (integrity assertions) — runs after the verify step, depends on the Release existing with a non-empty body
- Side-note: this PR adds another `gh api --include` candidate site for #178's fail-closed-helper extraction (release-body fetch) — not changing scope here, just noting.

🏴‍☠️ Logged by the Quartermaster. All hands review before we set sail.
