### PR TITLE
docs(release): inaugurate Quartermaster's Log ceremony with alpha.7 banter and conventions 📝

### DIFF
--- a/.github/release-notes/README.md
+++ b/.github/release-notes/README.md
@@ -1,0 +1,108 @@
+# Quartermaster's Log — Release Banter
+
+This directory holds optional curated banter files that the
+[`build-and-attach-apk.yml`](../workflows/build-and-attach-apk.yml)
+workflow prepends to the GitHub Release body, above the auto-generated
+changelog and section summary.
+
+For the workflow integration (auto-summary, milestone callout, idempotency,
+fail-soft semantics), see the "Annotate Release with Quartermaster's Log"
+step in [`build-and-attach-apk.yml`](../workflows/build-and-attach-apk.yml)
+and the [Recovery runbook](../workflows/RELEASE-PLEASE.md#recovery) for
+backfill operations.
+
+## What this directory is
+
+Each file describes a single release in a few paragraphs of curated prose.
+The workflow's annotation step:
+
+1. Looks for `.github/release-notes/<git-tag>.md` (e.g.
+   `v0.1.0-alpha.7.md`) when publishing tag `v0.1.0-alpha.7`
+2. If present, the file's content is rendered at the very top of the
+   Release body, above the milestone callout and section summary
+3. If absent, the Log header still renders with just the auto-summary —
+   no error, no warning
+
+## When to write one
+
+Banter is **optional, not required**. Most routine releases are well-served
+by the auto-summary alone. Write a banter file when the release has a story
+worth telling that the auto-summary cannot capture on its own:
+
+- **Milestone bookends** — the first or last release in a milestone, or any
+  release that marks a phase transition (alpha → beta, beta → stable)
+- **Incidents and recoveries** — a release that fixes a notable production
+  issue, or a republish after an incident
+- **Significant features or pivots** — a release that introduces or removes
+  something that future-us will want to remember the moment of
+- **Anything you'd want a reader to know on landing the page** — if the
+  auto-summary leaves a question unanswered, the banter is the place
+
+If a release doesn't need any of the above, skip the file. Silence is fine.
+
+## Naming
+
+```
+.github/release-notes/v<version>.md
+```
+
+The filename matches the git tag verbatim, including the leading `v`.
+Examples:
+
+- `v0.1.0-alpha.7.md`
+- `v0.2.0-beta.1.md`
+- `v1.0.0.md`
+
+The workflow looks for the exact filename based on its `tag` input. A
+mismatch (missing `v`, wrong casing) means the file is not picked up; the
+auto-summary still renders without it.
+
+## Format
+
+- **Pure markdown** — the file content is concatenated verbatim above the
+  milestone callout, with one blank line as separator. No frontmatter, no
+  preprocessing.
+- **Blockquote-led** is the established convention. The leading `>` lines
+  visually distinguish the curated banter from the auto-generated material
+  that follows.
+- **Length: ~150 words ideally**, hard cap ~250 words. The banter is a
+  header, not an essay. Readers landing on the Release page should be able
+  to absorb it in under 30 seconds.
+- **No code blocks or tables** unless they're load-bearing. The banter
+  precedes a Markdown changelog with its own structure; visual contrast is
+  the point.
+- **EOF newline** — Unix convention. Matches the rest of the repo.
+
+## Tone
+
+- **Pirate vibes welcome.** Match the project's broader idiom (the
+  `release-please-config.json` section names like "⛵ New Rigging" and
+  "🔧 Hull Repairs" are doing the same job at the changelog layer).
+- **Honest about alpha/beta/stable state.** "First watch stood" carries
+  the weight of "M1 milestone closed" without claiming the project is
+  finished. Avoid language that implies stability or arrival when the
+  project is still in alpha. Saying "alpha series, more hands on deck"
+  is honest; saying "production ready" would not be.
+- **Specific to *this* release.** Generic prose ("another solid release",
+  "great progress this cycle") adds no signal. Reference real artefacts:
+  PR numbers, issues, milestones, runbook sections, prior incidents.
+- **Concrete over decorative.** A line like "the release pipeline that
+  publishes this very release was rebuilt during this milestone" is
+  worth fifty lines of "we worked hard". Specificity earns the pirate
+  flavour; without it, the flavour reads as filler.
+
+## Idempotency note
+
+The workflow's annotation step is idempotent — re-runs against an
+already-annotated release skip the operation. This means manual edits to a
+Release body (including hand-tuning the curated banter post-publish)
+**survive subsequent reruns**. If you spot a typo after publish, edit the
+banter file *and* the live Release body; the workflow won't undo your fix.
+
+## Worked example
+
+[`v0.1.0-alpha.7.md`](v0.1.0-alpha.7.md) — the inaugural banter file. M1
+banner; references the recovery runbook and four integrity assertions;
+acknowledges alpha.6's 22-day cargo-overboard incident; carries the M1
+narrative without overstating. Length: 5 sentences across 2 paragraphs.
+Use it as the template for tone and length.

--- a/.github/release-notes/README.md
+++ b/.github/release-notes/README.md
@@ -8,8 +8,8 @@ changelog and section summary.
 For the workflow integration (auto-summary, milestone callout, idempotency,
 fail-soft semantics), see the "Annotate Release with Quartermaster's Log"
 step in [`build-and-attach-apk.yml`](../workflows/build-and-attach-apk.yml)
-and the [Recovery runbook](../workflows/RELEASE-PLEASE.md#recovery) for
-backfill operations.
+and the [Backfilling recipe](../workflows/RELEASE-PLEASE.md#backfilling-a-releases-body-retroactively)
+for retroactive body edits.
 
 ## What this directory is
 
@@ -102,7 +102,6 @@ banter file *and* the live Release body; the workflow won't undo your fix.
 ## Worked example
 
 [`v0.1.0-alpha.7.md`](v0.1.0-alpha.7.md) — the inaugural banter file. M1
-banner; references the recovery runbook and four integrity assertions;
-acknowledges alpha.6's 22-day cargo-overboard incident; carries the M1
-narrative without overstating. Length: 5 sentences across 2 paragraphs.
-Use it as the template for tone and length.
+banner; references the Recovery runbook and the four integrity assertions;
+carries the M1 narrative without overstating. Length: 6 sentences across
+2 paragraphs. Use it as the template for tone and length.

--- a/.github/release-notes/v0.1.0-alpha.7.md
+++ b/.github/release-notes/v0.1.0-alpha.7.md
@@ -1,0 +1,9 @@
+> **First watch stood.** alpha.7 is the M1 banner — the first
+> milestone of the alpha series, closed end-to-end. The voice
+> pipeline lives, the UX minimum is shipped, and the release
+> pipeline that publishes this very release was rebuilt during
+> this milestone (see the [Recovery runbook](../workflows/RELEASE-PLEASE.md#recovery)
+> for what failed and how it was repaired). This release was
+> inspected four ways before the log was sealed.
+>
+> Same alpha series, more hands on deck. M2 begins.

--- a/.github/workflows/RELEASE-PLEASE.md
+++ b/.github/workflows/RELEASE-PLEASE.md
@@ -331,3 +331,75 @@ gh workflow run republish-release.yml \
    errors) make recovery low-risk: an operator dispatching against the wrong tag, or
    against a healthy Release, will be refused with a clear message rather than silently
    clobbering.
+
+## Quartermaster's Log — release banter
+
+Every Release published by `build-and-attach-apk.yml` gets an automatic
+"🏴‍☠️ Quartermaster's Log" header prepended above the auto-generated changelog.
+The header combines:
+
+- **Optional curated banter** read from `.github/release-notes/<git-tag>.md`
+  if present
+- **Milestone callout** identifying the dominant milestone among the
+  changelog's referenced issues (when a strict majority exists)
+- **Section summary** — a one-line digest counting items per changelog
+  section (`⛵ new rigging`, `🔧 hull repairs`, etc.)
+
+Curated banter is **optional**. Most routine releases are well-served by the
+auto-summary alone; banter is for milestone bookends, incidents, and releases
+with a story worth telling. See
+[`.github/release-notes/README.md`](../release-notes/README.md) for tone,
+length, and naming conventions.
+
+## Backfilling a Release's body retroactively
+
+Occasionally a Release's body needs to be edited or re-annotated after publish
+— e.g. a release that shipped before the Quartermaster's Log feature existed,
+or a body that needs to reflect new context that the auto-summary couldn't have
+known at publish time. The workflow's annotation step is idempotent and
+**won't undo manual edits**, so retroactive backfill is safe.
+
+There are three ways to apply a retroactive change, in increasing CI cost and
+authenticity:
+
+1. **Direct `gh api` PATCH** (cheapest; no CI run, no rebuild). Compose the
+   desired body locally, write it to a file, and PATCH the Release:
+
+   ```bash
+   gh api "repos/${REPO}/releases/${release_id}" \
+     -X PATCH \
+     -F body=@/tmp/new-body.md
+   ```
+
+   Best for body-only changes (banter additions, typo fixes, prose updates).
+   The APK asset is untouched.
+
+2. **One-off helper script**. If the change involves recomputing the
+   Quartermaster's Log header (e.g. backfilling a missed banter file), a
+   transparent local shell script that mirrors the workflow's annotation
+   logic — same `gh api` calls, same `jq` filters, same idempotency check —
+   produces a previewable body, which is then PATCHed via Option 1. Keeps
+   the algorithm in one place; treat the script as one-off scaffolding,
+   not standing infrastructure (the workflow remains the source of truth).
+
+3. **`gh workflow run republish-release.yml -f tag=… -f version=… -f force=true`**
+   (most authentic, ~15 min CI). Re-runs the full reusable workflow against
+   the existing tag. Builds a fresh APK, uploads with `--clobber`, runs
+   integrity assertions, runs the annotation step. The APK SHA changes
+   (different runner, different build metadata) — fine for an alpha but
+   technically alters the asset. Use only when the asset itself needs to
+   be rebuilt, not for body-only fixes.
+
+When in doubt, use Option 1 for body fixes and Option 3 for asset fixes.
+Option 2 is for when an author wants the production code path's exact
+algorithm without the build cost.
+
+### Worked example: alpha.7's inaugural Log
+
+The Quartermaster's Log feature shipped after alpha.7 was already published.
+alpha.7's Release body was retroactively annotated using Option 1 — a
+transparent local shell script (re-using the workflow's algorithm) composed
+the Log header, the rendered output was reviewed visually, and the body was
+PATCHed in place. The APK asset was untouched. From alpha.8 onward the
+workflow's annotation step fires automatically; alpha.7 is the only Release
+that ever needed the retroactive treatment for this specific reason.

--- a/.github/workflows/RELEASE-PLEASE.md
+++ b/.github/workflows/RELEASE-PLEASE.md
@@ -363,9 +363,11 @@ There are three ways to apply a retroactive change, in increasing CI cost and
 authenticity:
 
 1. **Direct `gh api` PATCH** (cheapest; no CI run, no rebuild). Compose the
-   desired body locally, write it to a file, and PATCH the Release:
+   desired body locally, write it to a file, look up the Release id from its
+   tag, and PATCH the Release:
 
    ```bash
+   release_id="$(gh api "repos/${REPO}/releases/tags/${TAG}" --jq '.id')"
    gh api "repos/${REPO}/releases/${release_id}" \
      -X PATCH \
      -F body=@/tmp/new-body.md
@@ -397,9 +399,10 @@ algorithm without the build cost.
 ### Worked example: alpha.7's inaugural Log
 
 The Quartermaster's Log feature shipped after alpha.7 was already published.
-alpha.7's Release body was retroactively annotated using Option 1 — a
-transparent local shell script (re-using the workflow's algorithm) composed
-the Log header, the rendered output was reviewed visually, and the body was
-PATCHed in place. The APK asset was untouched. From alpha.8 onward the
-workflow's annotation step fires automatically; alpha.7 is the only Release
-that ever needed the retroactive treatment for this specific reason.
+alpha.7's Release body was retroactively annotated using **Option 2 to
+compose the header, then Option 1 to apply it** — a transparent local shell
+script (re-using the workflow's algorithm) composed the Log header, the
+rendered output was reviewed visually, and the body was PATCHed in place.
+The APK asset was untouched. From alpha.8 onward the workflow's annotation
+step fires automatically; alpha.7 is the only Release that ever needed the
+retroactive treatment for this specific reason.

--- a/.github/workflows/RELEASE-PLEASE.md
+++ b/.github/workflows/RELEASE-PLEASE.md
@@ -367,7 +367,14 @@ authenticity:
    tag, and PATCH the Release:
 
    ```bash
+   # Set these to match your context.
+   REPO="<owner>/<repo>"   # e.g. Klazomenai/deck-chat
+   TAG="<tag>"             # e.g. v0.1.0-alpha.7
+
+   # Look up the Release id for the tag.
    release_id="$(gh api "repos/${REPO}/releases/tags/${TAG}" --jq '.id')"
+
+   # Apply the PATCH.
    gh api "repos/${REPO}/releases/${release_id}" \
      -X PATCH \
      -F body=@/tmp/new-body.md


### PR DESCRIPTION
## 🏴‍☠️ Quartermaster's note

Inaugurate the ceremony — alpha.7's curated banter, the directory's writing conventions, and a cross-link from the release runbook. This is the first run; the choices made here become the de facto template for every future banter file (tone, length, format, naming).

After this PR merges, alpha.7's existing Release body will be retroactively annotated via Option 1 from the new "Backfilling a Release's body retroactively" recipe (transparent local script + `gh api` PATCH). That operation is tracked under the same issue (#183) and follows in a separate ceremony step — not in this PR — so the rendered output gets a visual review pass before landing.

## What changed

```
.github/release-notes/v0.1.0-alpha.7.md  (NEW — alpha.7 M1 banner banter, 82 words)
.github/release-notes/README.md          (NEW — directory conventions, 697 words)
.github/workflows/RELEASE-PLEASE.md      (+72 lines — banter intro + backfill recipe)
```

No functional workflow changes. The build-and-attach-apk.yml step from #181 already consumes `.github/release-notes/<tag>.md` files when present; this PR adds the first such file plus its conventions.

## File A — `.github/release-notes/v0.1.0-alpha.7.md`

The first banter file. Two paragraphs, five sentences, 82 words.

```markdown
> **First watch stood.** alpha.7 is the M1 banner — the first
> milestone of the alpha series, closed end-to-end. The voice
> pipeline lives, the UX minimum is shipped, and the release
> pipeline that publishes this very release was rebuilt during
> this milestone (see the [Recovery runbook](../workflows/RELEASE-PLEASE.md#recovery)
> for what failed and how it was repaired). This release was
> inspected four ways before the log was sealed.
>
> Same alpha series, more hands on deck. M2 begins.
```

Blockquote-led so it visually distinguishes from the auto-summary that follows. References real artefacts (Recovery runbook, four integrity assertions). Honest about alpha state ("same alpha series, more hands on deck"). Carries the M1 narrative without overstating ("first watch stood" implies more watches to come).

## File B — `.github/release-notes/README.md`

Directory conventions. Sections:

| Section | Purpose |
|---|---|
| What this directory is | Workflow integration pointer + behaviour summary |
| When to write one | Decision criteria — milestone bookends, incidents, releases with a story; default to no banter for routine releases |
| Naming | `v<version>.md` matching the git tag (with the `v`); examples |
| Format | Pure markdown, blockquote-led, ~150 word target, hard cap ~250, EOF newline |
| Tone | Pirate vibes welcome; honest about alpha/beta/stable state; specific to the release; concrete over decorative |
| Idempotency note | Workflow re-runs don't re-annotate; manual edits to Release body survive |
| Worked example | Pointer to alpha.7 as the template |

The directory README is what a future contributor stumbling onto the directory reads to understand the contract. Without it, they'd have to grep workflow YAML to figure out what these files do.

## File C — `.github/workflows/RELEASE-PLEASE.md` additions

Two new sections appended after the existing "Recovery" content.

### "Quartermaster's Log — release banter"

Brief intro explaining the auto-summary + milestone callout + curated banter composition. Cross-links to the directory README for tone/length/naming. Lives in the main release doc so anyone reading about releases discovers the banter system.

### "Backfilling a Release's body retroactively"

Three-option recipe for editing a Release body post-publish:

1. **Direct `gh api` PATCH** — body-only changes, cheapest, no CI run, no rebuild. Best for typo fixes, banter additions, prose updates.
2. **One-off helper script** — when an author wants the production code path's exact algorithm without the build cost. Treat as one-off scaffolding, not standing infrastructure.
3. **Full `republish-release.yml -f force=true`** — most authentic, ~15 min CI, asset SHA changes. Only when the asset itself needs rebuilding.

Includes a worked example for alpha.7's retroactive annotation (the Phase 3 step of #183) which uses Option 1.

## Verification

- [x] All three files staged and committed; new directory `.github/release-notes/` created
- [x] alpha.7 banter is under ~150 words (82 actual)
- [x] Banter uses blockquote format
- [x] Naming convention follows `v<version>.md` matching git tag (`v0.1.0-alpha.7.md`)
- [x] `nix develop --command actionlint -color .github/workflows/*.yml` exits 0 (sanity check; no functional workflow change)
- [x] Commit GPG-signed
- [ ] Copilot review pending

## Acceptance criteria mapping (#183)

- [x] `.github/release-notes/v0.1.0-alpha.7.md` exists with the M1 banner banter
- [x] `.github/release-notes/README.md` exists with the writing conventions
- [x] `.github/workflows/RELEASE-PLEASE.md` cross-links the directory README and includes a "Backfilling a Release's body retroactively" recipe
- [x] Banter file is under ~150 words (82); uses blockquote format
- [x] Naming convention documented: `v<version>.md` matching the git tag (with the `v`)
- [x] `actionlint` passes on all workflow files
- [ ] After PR merges: alpha.7's existing Release body is retroactively annotated via Option 1 (transparent local script + `gh api` PATCH). The rendered output is reviewed visually before the PATCH lands. **Pending.**

## Related

- Refs #183 — this PR (Phase 2 of the ceremony; Phase 3 follows after merge)
- Builds on #181 — the workflow feature that consumes these banter files
- Builds on #172 (Recovery runbook) — File C extends that section

🏴‍☠️ Logged by the Quartermaster. All hands review before we set sail.
