### PR TITLE
fix(release): use absolute URLs in release-notes banter for cross-context rendering 🐛

### DIFF
--- a/.github/release-notes/README.md
+++ b/.github/release-notes/README.md
@@ -71,11 +71,12 @@ auto-summary still renders without it.
 - **No code blocks or tables** unless they're load-bearing. The banter
   precedes a Markdown changelog with its own structure; visual contrast is
   the point.
-- **Links must be absolute URLs.** Banter content is rendered on the
-  GitHub Release page, where relative links like `../workflows/RELEASE-PLEASE.md`
-  do not resolve (no logical "current directory" exists in that context).
-  Use full URLs (`https://github.com/<owner>/<repo>/blob/main/...`) so links
-  work in any rendering context.
+- **In banter files, links must be absolute URLs.** Banter content is
+  rendered on the GitHub Release page, where relative links like
+  `../workflows/RELEASE-PLEASE.md` do not resolve (no logical "current
+  directory" exists in that context). Use full URLs
+  (`https://github.com/<owner>/<repo>/blob/main/...`) so links work in any
+  rendering context.
 - **EOF newline** — Unix convention. Matches the rest of the repo.
 
 ## Tone

--- a/.github/release-notes/README.md
+++ b/.github/release-notes/README.md
@@ -77,6 +77,12 @@ auto-summary still renders without it.
   directory" exists in that context). Use full URLs
   (`https://github.com/<owner>/<repo>/blob/main/...`) so links work in any
   rendering context.
+  - **Prefer reference-style links** for absolute URLs in banter files.
+    Define the URL on its own line at the bottom of the file and
+    reference it inline by name (`[Recovery runbook][recovery]` plus
+    `[recovery]: https://...` at the end). Keeps the prose wrap clean
+    in-repo, makes URL updates a single-line edit, and renders
+    identically on the Release page.
 - **EOF newline** — Unix convention. Matches the rest of the repo.
 
 ## Tone

--- a/.github/release-notes/README.md
+++ b/.github/release-notes/README.md
@@ -71,6 +71,11 @@ auto-summary still renders without it.
 - **No code blocks or tables** unless they're load-bearing. The banter
   precedes a Markdown changelog with its own structure; visual contrast is
   the point.
+- **Links must be absolute URLs.** Banter content is rendered on the
+  GitHub Release page, where relative links like `../workflows/RELEASE-PLEASE.md`
+  do not resolve (no logical "current directory" exists in that context).
+  Use full URLs (`https://github.com/<owner>/<repo>/blob/main/...`) so links
+  work in any rendering context.
 - **EOF newline** — Unix convention. Matches the rest of the repo.
 
 ## Tone

--- a/.github/release-notes/v0.1.0-alpha.7.md
+++ b/.github/release-notes/v0.1.0-alpha.7.md
@@ -2,7 +2,7 @@
 > milestone of the alpha series, closed end-to-end. The voice
 > pipeline lives, the UX minimum is shipped, and the release
 > pipeline that publishes this very release was rebuilt during
-> this milestone (see the [Recovery runbook](../workflows/RELEASE-PLEASE.md#recovery)
+> this milestone (see the [Recovery runbook](https://github.com/Klazomenai/deck-chat/blob/main/.github/workflows/RELEASE-PLEASE.md#recovery)
 > for what failed and how it was repaired). This release was
 > inspected four ways before the log was sealed.
 >

--- a/.github/release-notes/v0.1.0-alpha.7.md
+++ b/.github/release-notes/v0.1.0-alpha.7.md
@@ -2,8 +2,10 @@
 > milestone of the alpha series, closed end-to-end. The voice
 > pipeline lives, the UX minimum is shipped, and the release
 > pipeline that publishes this very release was rebuilt during
-> this milestone (see the [Recovery runbook](https://github.com/Klazomenai/deck-chat/blob/main/.github/workflows/RELEASE-PLEASE.md#recovery)
-> for what failed and how it was repaired). This release was
-> inspected four ways before the log was sealed.
+> this milestone (see the [Recovery runbook][recovery] for what
+> failed and how it was repaired). This release was inspected
+> four ways before the log was sealed.
 >
 > Same alpha series, more hands on deck. M2 begins.
+
+[recovery]: https://github.com/Klazomenai/deck-chat/blob/main/.github/workflows/RELEASE-PLEASE.md#recovery


### PR DESCRIPTION
## 🏴‍☠️ Quartermaster's note

Two-line content fix: the alpha.7 banter file uses an absolute URL for the Recovery runbook link (so it works on the GitHub Release page, not just when the file is viewed in-repo), and the directory README now requires absolute URLs as a documented convention so future banter authors don't replicate the bug. Caught during Phase 3 of the Quartermaster's Log ceremony — the visual-inspection-before-PATCH gate did its job.

## What changed

```
.github/release-notes/v0.1.0-alpha.7.md  (link form: relative → absolute)
.github/release-notes/README.md          (+5 lines: new Format bullet on link conventions)
```

Diff stat: `2 files changed, 6 insertions(+), 1 deletion(-)`. No functional workflow changes; sanity actionlint passes.

## The bug

The banter file's content is composed verbatim into the Release body by `build-and-attach-apk.yml`'s annotation step (introduced in #181). Whatever Markdown is in the banter file ends up rendered on the Release page. Relative links assume the banter file's directory as the rendering context:

- `../workflows/RELEASE-PLEASE.md#recovery` resolves correctly from `.github/release-notes/` (where the file lives) — this is why PR review on #184 didn't catch it
- The same content rendered on `/releases/tag/v0.1.0-alpha.7` has no logical "current directory" — the relative path either 404s or resolves to nonsense

### Before / After

```diff
- > pipeline that publishes this very release was rebuilt during
- > this milestone (see the [Recovery runbook](../workflows/RELEASE-PLEASE.md#recovery)
- > for what failed and how it was repaired). This release was
+ > pipeline that publishes this very release was rebuilt during
+ > this milestone (see the [Recovery runbook](https://github.com/Klazomenai/deck-chat/blob/main/.github/workflows/RELEASE-PLEASE.md#recovery)
+ > for what failed and how it was repaired). This release was
```

## The convention (added to README's Format section)

```markdown
- **Links must be absolute URLs.** Banter content is rendered on the
  GitHub Release page, where relative links like `../workflows/RELEASE-PLEASE.md`
  do not resolve (no logical "current directory" exists in that context).
  Use full URLs (`https://github.com/<owner>/<repo>/blob/main/...`) so links
  work in any rendering context.
```

## Reflection — same pattern, different layer

This is the **same "context layer made explicit" lesson** captured in `klazomenai/dotfiles#87` (the recipe-docs skill) and `feedback_recipe_context_layer.md` in Claude memory — applied here at the *link* layer rather than the recipe-variable layer:

- The skill's lesson: a recipe references `${VAR}` without showing how `${VAR}` comes to exist; cold-start reader fails
- This case: a Markdown link uses `../path/file` without acknowledging that the rendering context isn't always the file's repo location; renders broken

The pattern recurs because in both cases the writer has full situational context (the recipe author knows their `${REPO}` value; the link author knows the file's directory) and the published artefact gets read in a *different* context where that situational knowledge isn't restored.

The ceremony's Phase 3 visual-inspection-before-PATCH gate is exactly the kind of cold-start reader test the skill prescribes. It caught a bug that PR review on #184 didn't catch, because PR review reads the file in its repo context where the relative link works fine. **Different review surface; different bugs caught.** Worth folding this observation back into the skill body (likely in a future revision of dotfiles#87) — "different cold-start contexts catch different context-leaks; multiple review surfaces are not redundancy".

## Verification

- [x] `nix develop --command actionlint -color .github/workflows/*.yml` exits 0 (sanity check; no functional workflow change)
- [x] Banter file's link is now an absolute URL pointing at `.github/workflows/RELEASE-PLEASE.md#recovery`
- [x] README's Format section gains the absolute-URL convention with rationale
- [x] Commit GPG-signed
- [ ] Copilot review pending

## Acceptance criteria mapping (#185)

- [x] `.github/release-notes/v0.1.0-alpha.7.md` Recovery runbook link uses absolute URL form
- [x] `.github/release-notes/README.md` "Format" section includes the absolute-URL link convention
- [x] All other banter files (none today; future-proof) inherit the convention via the README
- [ ] **After PR merges**: Phase 3 of the Quartermaster's Log ceremony resumes — re-run `/tmp/annotate-alpha-7.sh`, visual inspection again, then PATCH alpha.7. **Pending.**

## Related

- Refs #185 — this PR
- Refs #181 — workflow feature that consumes banter files (introduced the rendering-context dependency)
- Refs #183 — inaugural ceremony PR that landed the file with the broken link
- Refs `klazomenai/dotfiles#87` — the recipe-docs skill capturing the "context layer made explicit" pattern this bug exemplifies

🏴‍☠️ Logged by the Quartermaster. All hands review before we set sail.
