### PR TITLE
chore(ci): scrub the deck — clear CI deprecation noise 🏗️

### DIFF
--- a/.github/workflows/build-and-attach-apk.yml
+++ b/.github/workflows/build-and-attach-apk.yml
@@ -25,6 +25,12 @@ permissions:
   contents: write
   issues: read
 
+# Opt into Node 24 ahead of GitHub's forced migration on 2026-06-02 (Node
+# 20 actions removed entirely 2026-09-16). Drop this env once upstreams
+# bump to Node-24-native versions and we update them deliberately.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   build-apk:
     name: Build and Attach Signed APK
@@ -61,8 +67,6 @@ jobs:
           ref: refs/tags/${{ steps.validate_tag.outputs.tag }}
 
       - uses: DeterminateSystems/nix-installer-action@v14
-
-      - uses: DeterminateSystems/magic-nix-cache-action@v8
 
       - name: Cache Gradle
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,12 @@ on:
     branches: [main]
   pull_request:
 
+# Opt into Node 24 ahead of GitHub's forced migration on 2026-06-02 (Node
+# 20 actions removed entirely 2026-09-16). Drop this env once upstreams
+# bump to Node-24-native versions and we update them deliberately.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   license-audit:
     # DeckChat is AGPL-3.0-or-later. The `licensee` Gradle plugin
@@ -19,8 +25,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: DeterminateSystems/nix-installer-action@v14
-
-      - uses: DeterminateSystems/magic-nix-cache-action@v8
 
       - name: Cache Gradle
         uses: actions/cache@v4
@@ -41,8 +45,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: DeterminateSystems/nix-installer-action@v14
-
-      - uses: DeterminateSystems/magic-nix-cache-action@v8
 
       - name: Cache Gradle
         uses: actions/cache@v4

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -20,6 +20,12 @@ on:
 permissions:
   contents: read
 
+# Opt into Node 24 ahead of GitHub's forced migration on 2026-06-02 (Node
+# 20 actions removed entirely 2026-09-16). Drop this env once upstreams
+# bump to Node-24-native versions and we update them deliberately.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   actionlint:
     runs-on: ubuntu-latest
@@ -27,8 +33,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: DeterminateSystems/nix-installer-action@v14
-
-      - uses: DeterminateSystems/magic-nix-cache-action@v8
 
       - name: Run actionlint
         run: nix develop --command actionlint -color

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,6 +10,12 @@ permissions:
   pull-requests: write
   issues: read
 
+# Opt into Node 24 ahead of GitHub's forced migration on 2026-06-02 (Node
+# 20 actions removed entirely 2026-09-16). Drop this env once upstreams
+# bump to Node-24-native versions and we update them deliberately.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   release-please:
     name: Release Please

--- a/.github/workflows/republish-release.yml
+++ b/.github/workflows/republish-release.yml
@@ -28,6 +28,12 @@ permissions:
   contents: write
   issues: read
 
+# Opt into Node 24 ahead of GitHub's forced migration on 2026-06-02 (Node
+# 20 actions removed entirely 2026-09-16). Drop this env once upstreams
+# bump to Node-24-native versions and we update them deliberately.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   guard:
     name: Safety guard — refuse to overwrite existing Release


### PR DESCRIPTION
Last leg of the fleet-wide CI hygiene trilogy. Same pattern as the closed sister issues on chart-house ([#5](https://github.com/Klazomenai/chart-house/issues/5)) and Bridge ([#138](https://github.com/Klazomenai/bridge/issues/138)).

## What changed

Two coordinated changes across five workflow files:

| Workflow | `magic-nix-cache-action@v8` removed | `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` added |
|---|---|---|
| `ci.yml` | ✓ (×2 jobs: license-audit + build) | ✓ |
| `build-and-attach-apk.yml` | ✓ | ✓ |
| `lint-workflows.yml` | ✓ | ✓ |
| `release-please.yml` | n/a (didn't use it) | ✓ |
| `republish-release.yml` | n/a (didn't use it) | ✓ |

## Why

- `magic-nix-cache-action@v8` throws a `failure`-level FlakeHub auth annotation in newer runner behaviour. Drop > register > migrate, given DeckChat's solo-scale CI doesn't really need the ~30s cache speedup.
- Node 20 actions are forced to Node 24 starting 2026-06-02 and removed 2026-09-16. The env var opts in early — future-safe — drops cleanly when upstreams ship Node-24-native versions.

## Local smoke-test

```
nix develop --command actionlint -color .github/workflows/*.yml   → clean (no output, no issues)
```

## Acceptance criteria from #218

- [x] Drop `magic-nix-cache-action@v8` from `ci.yml` (both jobs), `build-and-attach-apk.yml`, and `lint-workflows.yml`
- [x] Set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` at workflow env level on all five workflows
- [ ] CI run on the merge commit shows zero `failure`-level annotations *(verifiable post-merge)*
- [ ] Node 20 deprecation warning substantively resolved *(verifiable post-merge — should change to "are being forced to run on Node.js 24" informational, matching chart-house and Bridge)*
- [ ] All CI jobs still pass: `license-audit`, `build`, `instrumented-tests` *(verifiable post-merge)*
- [ ] Release pipeline still functions: next release-please cycle works, signed APK builds via `build-and-attach-apk` still succeed *(verifiable on next release cycle)*

## Risk factors

- **Android emulator job** (`instrumented-tests`) is delicate — verify it still passes under env var.
- **Release pipeline** (`build-and-attach-apk.yml`) is critical to APK distribution. Don't break the signed build flow. Smoke-test on next release.
- Without Nix cache, first-time tool installs add ~30s to each Nix-using job. Acceptable trade for clean run output.

## Squash-commit subject

`chore(ci): scrub the deck — clear CI deprecation noise 🏗️`

Refs #218
