### PR TITLE
refactor(ci): extract fail-closed gh-api status-case as shared helper

### DIFF
--- a/.github/scripts/gh-api.sh
+++ b/.github/scripts/gh-api.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Shared helper for "ask GitHub about a release/tag/asset state, get back the
+# HTTP status + response body, and let the caller dispatch on it".
+#
+# Designed for release-workflow scripts where 200/404 mean different things at
+# different call sites (e.g. `build-and-attach-apk.yml :: create-or-update`
+# treats 404 as "create the Release"; the integrity assertion right after it
+# treats 404 as a hard failure). The case-statement therefore stays in the
+# caller — this helper only owns the gh-invocation + HTTP-status parsing +
+# body extraction, never the per-site decision.
+#
+# Usage:
+#   source "$GITHUB_WORKSPACE/.github/scripts/gh-api.sh"
+#   gh_api_with_status "repos/${REPO}/releases/tags/${TAG}" || true
+#   case "$GH_API_HTTP_STATUS" in
+#     200) release_json="$GH_API_BODY"; ... ;;
+#     404) ...                                ;;
+#     *)   echo "::error::Unexpected HTTP $GH_API_HTTP_STATUS"
+#          printf '%s\n' "$GH_API_RESPONSE"
+#          exit 1                              ;;
+#   esac
+#
+# Sets (in caller scope, intentionally — these are the helper's output):
+#   GH_API_RESPONSE     — full response from `gh api --include`, headers + body
+#   GH_API_BODY         — response body with HTTP headers stripped
+#   GH_API_HTTP_STATUS  — parsed status code ("200", "404", ...) or "unknown"
+#                         when no `HTTP/x.y NNN` header could be parsed.
+#
+# Returns:
+#   0 — status header parsed (regardless of which status). Caller dispatches.
+#   1 — gh failed AND no status header was parseable. GH_API_HTTP_STATUS is
+#       set to "unknown" so callers that wrap with `|| true` and dispatch
+#       on a `*)` case still get a sane fall-through value.
+#
+# Notes:
+#   - On HTTP redirects, the FIRST `HTTP/x.y` header wins. `gh api` typically
+#     follows redirects internally and emits only the final response, so this
+#     matches the documented gh behaviour for our endpoints (releases/tags).
+#   - The body separator is the first blank line, CR-tolerant for HTTP/1.x
+#     responses that still carry CRLF terminators.
+
+set -euo pipefail
+
+gh_api_with_status() {
+  # `|| true`-style capture: a non-zero exit from gh on a 4xx/5xx surface is
+  # the caller's `case` to dispatch, not ours. We only fail-close if the
+  # status header itself cannot be parsed below.
+  GH_API_RESPONSE=""
+  GH_API_BODY=""
+  GH_API_HTTP_STATUS=""
+
+  GH_API_RESPONSE="$(gh api --include "$@" 2>&1)" || true
+
+  GH_API_HTTP_STATUS="$(printf '%s\n' "$GH_API_RESPONSE" \
+    | awk '/^HTTP\/[0-9.]+ [0-9]+/ { print $2; exit }')"
+
+  if [ -z "$GH_API_HTTP_STATUS" ]; then
+    GH_API_HTTP_STATUS="unknown"
+    return 1
+  fi
+
+  # shellcheck disable=SC2034
+  # GH_API_BODY is part of the helper's output contract — consumed by callers.
+  GH_API_BODY="$(printf '%s\n' "$GH_API_RESPONSE" \
+    | awk 'in_body { print; next } /^\r?$/ { in_body = 1 }')"
+
+  return 0
+}

--- a/.github/scripts/test-gh-api.sh
+++ b/.github/scripts/test-gh-api.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Shell-level unit test for gh-api.sh — exercises the three documented
+# return paths (200, 404, unparseable) against a stubbed `gh` function.
+#
+# Run locally:
+#   bash .github/scripts/test-gh-api.sh
+# Exits non-zero on any assertion failure so CI gates on it.
+#
+# Why this exists: the helper's HTTP-header parsing and body extraction
+# are easy to break with a sed/awk regression. The smoke test runs in
+# under 100 ms, has zero external dependencies (no network, no `gh`
+# binary), and pins the three documented return paths so a future edit
+# to gh-api.sh can't silently degrade them.
+
+set -euo pipefail
+THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Stub `gh` — selected via the endpoint argument passed by the helper's
+# `gh api --include "$@"` invocation. The helper passes args verbatim, so
+# inside the stub: $1=api, $2=--include, $3=<endpoint>.
+gh() {
+  case "${3:-}" in
+    *tags/v200*)
+      printf 'HTTP/2.0 200 OK\r\nContent-Type: application/json\r\n\r\n{"id":12345,"name":"v0.1.0-alpha.7"}\n'
+      return 0
+      ;;
+    *tags/v404*)
+      printf 'HTTP/2.0 404 Not Found\r\nContent-Type: application/json\r\n\r\n{"message":"Not Found"}\n'
+      return 1
+      ;;
+    *broken*)
+      # Simulate a transport failure: `gh` exits non-zero AND no HTTP/x.y
+      # header is parseable. This is the helper's fail-closed path.
+      printf 'connection refused\n' >&2
+      return 1
+      ;;
+    *)
+      printf 'unexpected test endpoint: %s\n' "${3:-}" >&2
+      return 2
+      ;;
+  esac
+}
+export -f gh
+
+# shellcheck source=.github/scripts/gh-api.sh
+source "${THIS_DIR}/gh-api.sh"
+
+failures=0
+assert_eq() {
+  local actual="$1" expected="$2" name="$3"
+  if [ "$actual" = "$expected" ]; then
+    printf 'ok: %s\n' "$name"
+  else
+    printf 'FAIL: %s: expected %q, got %q\n' "$name" "$expected" "$actual" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+# --- Test 1: 200 OK -----------------------------------------------------------
+# Status parsed; body extracted; helper rc=0.
+rc=0
+gh_api_with_status "repos/x/releases/tags/v200" || rc=$?
+assert_eq "$GH_API_HTTP_STATUS" "200" "200: status parsed"
+assert_eq "$GH_API_BODY" '{"id":12345,"name":"v0.1.0-alpha.7"}' "200: body extracted"
+assert_eq "$rc" "0" "200: helper rc=0"
+
+# --- Test 2: 404 Not Found ----------------------------------------------------
+# Status parsed; body extracted; helper rc=0 (parseable status, even though
+# `gh` itself exited 1 — that's the case-dispatch's job, not the helper's).
+rc=0
+gh_api_with_status "repos/x/releases/tags/v404" || rc=$?
+assert_eq "$GH_API_HTTP_STATUS" "404" "404: status parsed"
+assert_eq "$GH_API_BODY" '{"message":"Not Found"}' "404: body extracted"
+assert_eq "$rc" "0" "404: helper rc=0 despite gh exit 1"
+
+# --- Test 3: unparseable (no HTTP headers) -----------------------------------
+# Fail-closed: status=unknown, helper rc=1, body left empty.
+rc=0
+gh_api_with_status "broken" || rc=$?
+assert_eq "$GH_API_HTTP_STATUS" "unknown" "unparseable: status=unknown"
+assert_eq "$rc" "1" "unparseable: helper rc=1"
+
+# --- Summary -----------------------------------------------------------------
+if [ "$failures" -gt 0 ]; then
+  printf 'FAILED: %d assertion(s)\n' "$failures" >&2
+  exit 1
+fi
+printf 'PASSED: all gh-api.sh assertions\n'

--- a/.github/workflows/RELEASE-PLEASE.md
+++ b/.github/workflows/RELEASE-PLEASE.md
@@ -250,6 +250,10 @@ What to expect after dispatch:
    - Validates the `tag`/`version` inputs against the regex from
      `app/build.gradle.kts`'s `computeVersionCode`
    - Checks out `refs/tags/<tag>` (forces tag-only resolution)
+   - Performs a **second sparse checkout at the workflow's own ref** into
+     `ci-helpers/` to vendor `.github/scripts/*.sh` — so historical tags
+     that predate a CI helper still republish cleanly without the source
+     line dying at a missing file
    - Builds and signs the APK
    - Calls `gh release upload --clobber` (200 path) or `gh release create --prerelease
      --generate-notes` (404 path)
@@ -278,6 +282,11 @@ properly published.
 - **Don't manually upload a locally-built APK.** Local builds bypass the CI provenance
   chain. The signing key and build environment are the same in both cases, but the
   audit trail is not — every published artefact should be traceable to a CI workflow run.
+- **Don't move CI helper scripts back into the tag-checkout source tree.** The reusable
+  workflow vendors `.github/scripts/*.sh` from the workflow's own ref into `ci-helpers/`
+  so republishing pre-script tags works. Inlining the helpers into the tag-checkout tree
+  would re-introduce the historical-tag break — `v0.1.0-alpha.6` and any other tag
+  predating a helper's introduction would die at the first `source` line.
 
 ### Worked example: the v0.1.0-alpha.6 incident (2026-04-03 → 2026-04-27)
 

--- a/.github/workflows/build-and-attach-apk.yml
+++ b/.github/workflows/build-and-attach-apk.yml
@@ -111,13 +111,15 @@ jobs:
           TAG: ${{ inputs.tag }}
           VERSION: ${{ inputs.version }}
         run: |
-          set -euo pipefail
+          # gh-api.sh itself sets `set -euo pipefail` on source.
+          source "$GITHUB_WORKSPACE/.github/scripts/gh-api.sh"
           APK="app/build/outputs/apk/release/deck-chat-${VERSION}.apk"
-          gh_response="$(gh api --include "repos/${REPO}/releases/tags/${TAG}" 2>&1)" || gh_status=$?
-          gh_status="${gh_status:-0}"
-          http_status="$(printf '%s\n' "$gh_response" | awk '/^HTTP\/[0-9.]+ [0-9]+/ { print $2; exit }')"
 
-          case "$http_status" in
+          # `|| true` so a parseable 4xx/5xx (or the "unknown" fail-closed
+          # path) reaches the case below rather than triggering set -e exit.
+          gh_api_with_status "repos/${REPO}/releases/tags/${TAG}" || true
+
+          case "$GH_API_HTTP_STATUS" in
             200)
               echo "Release $TAG exists — uploading asset (clobber)."
               gh release upload "$TAG" "$APK" --clobber
@@ -130,8 +132,8 @@ jobs:
                 --title "$TAG"
               ;;
             *)
-              echo "::error::Unexpected response while checking Release for tag ${TAG} (HTTP ${http_status:-unknown}, gh api exit ${gh_status})."
-              printf '%s\n' "$gh_response"
+              echo "::error::Unexpected response while checking Release for tag ${TAG} (HTTP ${GH_API_HTTP_STATUS})."
+              printf '%s\n' "$GH_API_RESPONSE"
               exit 1
               ;;
           esac
@@ -143,20 +145,21 @@ jobs:
           TAG: ${{ inputs.tag }}
           VERSION: ${{ inputs.version }}
         run: |
-          set -euo pipefail
+          # gh-api.sh itself sets `set -euo pipefail` on source.
+          source "$GITHUB_WORKSPACE/.github/scripts/gh-api.sh"
           apk_name="deck-chat-${VERSION}.apk"
 
           # Assertion 1: Release exists for the tag.
-          # We just created or upload-clobbered the Release, so a non-zero exit
-          # from `gh api` here indicates a real problem (transient API failure,
+          # We just created or upload-clobbered the Release, so anything other
+          # than HTTP 200 here indicates a real problem (transient API failure,
           # permission regression, or the upstream create/upload silently failed).
-          release_json="$(gh api "repos/${REPO}/releases/tags/${TAG}" 2>&1)" || api_status=$?
-          api_status="${api_status:-0}"
-          if [ "$api_status" -ne 0 ]; then
-            echo "::error::Assertion 1 failed (Release exists): could not query Release ${TAG} (gh api exit ${api_status})."
-            printf '%s\n' "$release_json"
+          gh_api_with_status "repos/${REPO}/releases/tags/${TAG}" || true
+          if [ "$GH_API_HTTP_STATUS" != "200" ]; then
+            echo "::error::Assertion 1 failed (Release exists): could not query Release ${TAG} (HTTP ${GH_API_HTTP_STATUS})."
+            printf '%s\n' "$GH_API_RESPONSE"
             exit 1
           fi
+          release_json="$GH_API_BODY"
 
           # Assertion 2: prerelease == true.
           # Matches release-please-config.json `prerelease: true` and the
@@ -193,16 +196,19 @@ jobs:
           REPO: ${{ github.repository }}
           TAG: ${{ inputs.tag }}
         run: |
-          set -euo pipefail
+          # gh-api.sh itself sets `set -euo pipefail` on source.
+          source "$GITHUB_WORKSPACE/.github/scripts/gh-api.sh"
 
-          # Fetch current Release body and id.
-          release_json="$(gh api "repos/${REPO}/releases/tags/${TAG}" 2>&1)" || api_status=$?
-          api_status="${api_status:-0}"
-          if [ "$api_status" -ne 0 ]; then
-            echo "::error::Failed to fetch Release ${TAG} for annotation (gh api exit ${api_status})."
-            printf '%s\n' "$release_json"
+          # Fetch current Release body and id. The integrity step above
+          # already confirmed Release-exists, so anything other than HTTP 200
+          # here is a transient failure or permission regression.
+          gh_api_with_status "repos/${REPO}/releases/tags/${TAG}" || true
+          if [ "$GH_API_HTTP_STATUS" != "200" ]; then
+            echo "::error::Failed to fetch Release ${TAG} for annotation (HTTP ${GH_API_HTTP_STATUS})."
+            printf '%s\n' "$GH_API_RESPONSE"
             exit 1
           fi
+          release_json="$GH_API_BODY"
           release_id="$(printf '%s' "$release_json" | jq -r '.id // empty')"
           if [ -z "$release_id" ]; then
             echo "::error::Failed to determine Release id for ${TAG}; response was malformed."

--- a/.github/workflows/build-and-attach-apk.yml
+++ b/.github/workflows/build-and-attach-apk.yml
@@ -66,6 +66,20 @@ jobs:
         with:
           ref: refs/tags/${{ steps.validate_tag.outputs.tag }}
 
+      - name: Checkout CI helper scripts at workflow ref
+        # Republish runs check out the tag (above) to build APK sources from
+        # that point in history. CI helper scripts under .github/scripts/ may
+        # not exist in older tags' trees, so source them from the workflow's
+        # own ref (typically main) into a side path. Done AFTER the tag
+        # checkout so the tag checkout's clean step can't remove them.
+        uses: actions/checkout@v4
+        with:
+          # No `ref:` — defaults to the workflow's ref (github.sha for the
+          # caller's commit), where the helper definitely exists.
+          sparse-checkout: |
+            .github/scripts
+          path: ci-helpers
+
       - uses: DeterminateSystems/nix-installer-action@v14
 
       - name: Cache Gradle
@@ -112,7 +126,7 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           # gh-api.sh itself sets `set -euo pipefail` on source.
-          source "$GITHUB_WORKSPACE/.github/scripts/gh-api.sh"
+          source "$GITHUB_WORKSPACE/ci-helpers/.github/scripts/gh-api.sh"
           APK="app/build/outputs/apk/release/deck-chat-${VERSION}.apk"
 
           # `|| true` so a parseable 4xx/5xx (or the "unknown" fail-closed
@@ -146,7 +160,7 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           # gh-api.sh itself sets `set -euo pipefail` on source.
-          source "$GITHUB_WORKSPACE/.github/scripts/gh-api.sh"
+          source "$GITHUB_WORKSPACE/ci-helpers/.github/scripts/gh-api.sh"
           apk_name="deck-chat-${VERSION}.apk"
 
           # Assertion 1: Release exists for the tag.
@@ -197,7 +211,7 @@ jobs:
           TAG: ${{ inputs.tag }}
         run: |
           # gh-api.sh itself sets `set -euo pipefail` on source.
-          source "$GITHUB_WORKSPACE/.github/scripts/gh-api.sh"
+          source "$GITHUB_WORKSPACE/ci-helpers/.github/scripts/gh-api.sh"
 
           # Fetch current Release body and id. The integrity step above
           # already confirmed Release-exists, so anything other than HTTP 200

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - '.github/workflows/**'
+      - '.github/scripts/**'
       - 'devenv.nix'
       - 'devenv.lock'
       - 'flake.nix'
@@ -12,6 +13,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/**'
+      - '.github/scripts/**'
       - 'devenv.nix'
       - 'devenv.lock'
       - 'flake.nix'
@@ -36,3 +38,13 @@ jobs:
 
       - name: Run actionlint
         run: nix develop --command actionlint -color
+
+  scripts-test:
+    # Unit tests for the reusable shell helpers under .github/scripts/.
+    # Runs without network or `gh` (stubbed), so it's safe on any runner.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Test gh-api.sh helper (Refs #178)
+        run: bash .github/scripts/test-gh-api.sh

--- a/.github/workflows/republish-release.yml
+++ b/.github/workflows/republish-release.yml
@@ -40,13 +40,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout for gh-api helper
-        # Lightweight checkout — `.github/scripts/gh-api.sh` is sourced by
-        # the next step. Sparse paths keep this cheap (~1-2s).
+        # Lightweight cone-mode sparse checkout — `.github/scripts/gh-api.sh`
+        # is sourced by the next step. Cone mode (the default) treats listed
+        # paths as directory cones and includes their contents; switching to
+        # non-cone mode here would pattern-match the path itself, which can
+        # leave the helper file un-checked-out depending on git's interpretation.
         uses: actions/checkout@v4
         with:
           sparse-checkout: |
             .github/scripts
-          sparse-checkout-cone-mode: false
 
       - name: Refuse if Release exists and force is false
         env:

--- a/.github/workflows/republish-release.yml
+++ b/.github/workflows/republish-release.yml
@@ -39,6 +39,15 @@ jobs:
     name: Safety guard — refuse to overwrite existing Release
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout for gh-api helper
+        # Lightweight checkout — `.github/scripts/gh-api.sh` is sourced by
+        # the next step. Sparse paths keep this cheap (~1-2s).
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github/scripts
+          sparse-checkout-cone-mode: false
+
       - name: Refuse if Release exists and force is false
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -47,13 +56,15 @@ jobs:
           VERSION: ${{ inputs.version }}
           FORCE: ${{ inputs.force }}
         run: |
-          set -euo pipefail
+          # gh-api.sh itself sets `set -euo pipefail` on source.
+          source "$GITHUB_WORKSPACE/.github/scripts/gh-api.sh"
           apk_name="deck-chat-${VERSION}.apk"
-          gh_response="$(gh api --include "repos/${REPO}/releases/tags/${TAG}" 2>&1)" || gh_status=$?
-          gh_status="${gh_status:-0}"
-          http_status="$(printf '%s\n' "$gh_response" | awk '/^HTTP\/[0-9.]+ [0-9]+/ { print $2; exit }')"
 
-          case "$http_status" in
+          # `|| true` so a parseable 4xx/5xx (or the "unknown" fail-closed
+          # path) reaches the case below rather than triggering set -e exit.
+          gh_api_with_status "repos/${REPO}/releases/tags/${TAG}" || true
+
+          case "$GH_API_HTTP_STATUS" in
             200)
               # Release exists. Refuse only if the specific APK asset is already attached
               # (would-clobber); proceed if the Release exists but the asset is missing
@@ -83,8 +94,8 @@ jobs:
               echo "No existing Release for tag ${TAG} — proceeding to (re)publish."
               ;;
             *)
-              echo "::error::Unexpected response while checking Release for tag ${TAG} (HTTP ${http_status:-unknown}, gh api exit ${gh_status})."
-              printf '%s\n' "$gh_response"
+              echo "::error::Unexpected response while checking Release for tag ${TAG} (HTTP ${GH_API_HTTP_STATUS})."
+              printf '%s\n' "$GH_API_RESPONSE"
               exit 1
               ;;
           esac

--- a/.github/workflows/republish-release.yml
+++ b/.github/workflows/republish-release.yml
@@ -70,16 +70,22 @@ jobs:
               # (would-clobber); proceed if the Release exists but the asset is missing
               # (a legitimate recovery case — the alpha.6 variant where the Release object
               # exists but no APK was ever attached).
-              asset_lookup_output="$(gh api "repos/${REPO}/releases/tags/${TAG}" \
-                   --jq ".assets[] | select(.name == \"${apk_name}\") | .name" 2>&1)" || asset_lookup_status=$?
-              asset_lookup_status="${asset_lookup_status:-0}"
-              if [ "$asset_lookup_status" -ne 0 ]; then
-                echo "::error::Failed to check whether Release ${TAG} already has asset ${apk_name} (gh api exit ${asset_lookup_status})."
-                printf '%s\n' "$asset_lookup_output"
+              #
+              # $GH_API_BODY (set by gh_api_with_status above) already contains the full
+              # Release JSON including the `.assets` array — so we filter locally with jq
+              # instead of issuing a second API request. `.assets[]?` is `?`-suffixed so
+              # a malformed-or-null assets field surfaces as empty rather than a jq error.
+              asset_attached="$(printf '%s' "$GH_API_BODY" \
+                | jq -r --arg name "${apk_name}" '.assets[]? | select(.name == $name) | .name')" \
+                || jq_status=$?
+              jq_status="${jq_status:-0}"
+              if [ "$jq_status" -ne 0 ]; then
+                echo "::error::Failed to parse Release JSON for ${TAG} (jq exit ${jq_status})."
+                printf '%s\n' "$GH_API_BODY"
                 exit 1
               fi
 
-              if printf '%s\n' "$asset_lookup_output" | grep -Fqx -- "${apk_name}"; then
+              if printf '%s\n' "$asset_attached" | grep -Fqx -- "${apk_name}"; then
                 if [ "$FORCE" = "true" ]; then
                   echo "::warning::Release ${TAG} already has asset ${apk_name}; force=true → proceeding (will clobber asset)."
                 else


### PR DESCRIPTION
## Summary

Extracts the fail-closed `gh api --include` + status-case shell pattern from across the release-workflow set into a single sourced helper at `.github/scripts/gh-api.sh`. Adds a shell-level unit test covering the three documented return paths and wires it into the existing `lint-workflows.yml`.

Net: 5 helper consumer sites, 1 helper, 1 test, 1 CI job.

## Mechanism (Option B: sourced shell function)

Per the M2 plan's S4 review, **Option B** was chosen over **Option A** (composite action):

> The two existing call sites have different per-status decisions; centralising masks them. A naively-extracted "fail-closed `gh-api` helper" that owned the case statement would either need an explicit `--on-404 create|fail` flag (turning a one-line shell pattern into a config DSL — bad), or would have to eat the case statement and lose the per-site decision (worse).

So the helper returns `(http_status, body, raw_response)` to the caller — **the case-statement stays in the workflow**, the helper does not own the decision.

Helper contract (see `gh-api.sh` header):

| Variable | Set to |
|---|---|
| `GH_API_RESPONSE` | full `gh api --include` output, headers + body |
| `GH_API_BODY` | response body with HTTP headers stripped |
| `GH_API_HTTP_STATUS` | parsed status code (`"200"`, `"404"`, ...) or `"unknown"` |

Return code: `0` on parseable status (regardless of value), `1` only when no `HTTP/x.y NNN` header is parseable. Callers wrap with `|| true` so a `*)` case can fall through `"unknown"`.

`set -euo pipefail` is set by the helper script itself — callers no longer set it explicitly (relied on `source`).

## Call sites consumed (5)

| Workflow | Step | Dispatch shape |
|---|---|---|
| `republish-release.yml` | guard :: existence check | 200/404/* |
| `republish-release.yml` | guard :: asset-attached check | reuses `$GH_API_BODY` from the outer call (no second API request) |
| `build-and-attach-apk.yml` | create-or-update | 200/404/* |
| `build-and-attach-apk.yml` | Verify integrity :: Assertion 1 | 200-or-fail |
| `build-and-attach-apk.yml` | Annotate Quartermaster's Log | 200-or-fail |

## Test surface

`.github/scripts/test-gh-api.sh` — bash stubs `gh` (no network, no `gh` binary). Asserts the three documented return paths:

- `200 OK` → status parsed, body extracted, helper `rc=0`
- `404 Not Found` → status parsed, body extracted, helper `rc=0` (despite `gh` exit 1)
- unparseable → status=`unknown`, helper `rc=1`

8 assertions total, exits non-zero on any failure. Wired into `lint-workflows.yml` as a new `scripts-test` job. Paths filter expanded with `.github/scripts/**` so a future edit to `gh-api.sh` trips the test gate.

## Why no Kover (#207)

The plan called for bundling #207 (Kover XML emit) with this PR. Local investigation showed **Kover 0.9.1 produces an empty report on AGP 9** — the `.artifact` file contains only `:app` with no classes, and all counters render as `0/0/0`. Root cause appears to be upstream: AGP 9 no longer applies the `kotlin-android` plugin, and Kover's compile-time instrumentation needs the Kotlin Gradle Plugin to hook in.

Shipping the wiring with empty reports would be misleading. #207 stays open as a separate Kover/AGP-9 compatibility track.

## AC walk (#178)

- [x] Option A/B chosen + rationale in PR body — **B, see Mechanism above**
- [x] All three call sites in the issue body table refactored — and two more besides
- [x] Helper has at least one test case — `test-gh-api.sh`, 8 assertions
- [x] No behavioural regression: 200/404/* dispatch preserved (republish 200-branch now uses 1 API call instead of 2, but the dispatch matrix is unchanged)
- [x] `actionlint` passes on all callers
- [x] _Plan AC-#178.1_ signature + caller owns case
- [x] _Plan AC-#178.2_ fail-closed on unparseable (`rc=1`, status=`unknown`)
- [x] _Plan AC-#178.3_ at least 3 sites (we have 5)
- [x] _Plan AC-#178.4_ `set -euo pipefail` preserved (helper sets it)

## Test plan

- [ ] CI: `Lint Workflows / actionlint` green
- [ ] CI: `Lint Workflows / scripts-test` green (new job — exercises the helper end-to-end)
- [ ] CI: `CI / build` green (sanity — Gradle config untouched on the build path)
- [ ] CI: `CI / license-audit` green (sanity — no dep changes)
- [ ] Manual smoke (post-merge, optional): trigger `republish-release.yml` against an existing tag — guard should refuse-without-force (asset already attached). Validates the helper end-to-end against the real `gh api --include` response shape.

Closes #178

Generated with [Claude Code](https://claude.com/claude-code)
