### PR TITLE
refactor(viewmodel): cancel viewModelScope in releaseResources for test safety ♻️

### DIFF
--- a/app/src/main/java/dev/klazomenai/deckchat/MainViewModel.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/MainViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -16,6 +17,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
@@ -285,8 +287,26 @@ class MainViewModel(
         releaseResources()
     }
 
+    /**
+     * Cleans up the ViewModel's owned resources. Called from [onCleared] in the
+     * production lifecycle (after the framework cancels [viewModelScope] via
+     * `super.onCleared`), and called **directly** by JVM test teardown without
+     * the framework cancel ever firing.
+     *
+     * For the test path to be honest, this method itself cancels [viewModelScope]
+     * before closing channels and engines — otherwise in-flight pipelines
+     * launched into the scope can keep collecting [RecordingService.serviceEvents]
+     * and fire into freshly-closed channels, producing noisy red-herring errors
+     * in test failure logs as more online-mode tests land. In the production
+     * path the cancel is a no-op (the scope was already cancelled by
+     * `super.onCleared`), which is the intended idempotency.
+     *
+     * The `matrixClient.stop()` runs on a `NonCancellable` IO context after the
+     * scope cancel, so the Matrix shutdown sequence is not interrupted.
+     */
     @VisibleForTesting
     internal fun releaseResources() {
+        viewModelScope.cancel()
         crewMessages.close()
         sttEngine.close()
         ttsEngine.close()
@@ -294,6 +314,15 @@ class MainViewModel(
             runBlocking(Dispatchers.IO + NonCancellable) { client.stop() }
         }
     }
+
+    /**
+     * Exposes [viewModelScope]'s active-or-cancelled state for assertions in
+     * unit tests. The scope is active from construction until [releaseResources]
+     * runs (or until the framework's `super.onCleared` fires in production).
+     */
+    @VisibleForTesting
+    internal val isScopeActive: Boolean
+        get() = viewModelScope.isActive
 
     class Factory(
         private val sttEngine: SttEngine,

--- a/app/src/test/java/dev/klazomenai/deckchat/MainViewModelTest.kt
+++ b/app/src/test/java/dev/klazomenai/deckchat/MainViewModelTest.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -129,6 +130,22 @@ class MainViewModelTest {
         viewModel.setState(PipelineState.Transcribed("hello"))
         assertTrue(viewModel.state.value is PipelineState.Transcribed)
         assertEquals("hello", (viewModel.state.value as PipelineState.Transcribed).text)
+    }
+
+    @Test
+    fun `releaseResources cancels viewModelScope`() {
+        // Guards the JVM-test cleanup contract: tearDown() calls releaseResources()
+        // directly without the framework's super.onCleared() firing first, so
+        // releaseResources() itself must cancel viewModelScope to stop in-flight
+        // RecordingService.serviceEvents collectors from firing pipelines into
+        // the freshly-closed crewMessages channel. This test is also the safety
+        // net for #161 / #162 which depend on the cancel-then-close ordering.
+        val viewModel = createViewModel()
+        assertTrue("viewModelScope should be active before releaseResources", viewModel.isScopeActive)
+
+        viewModel.releaseResources()
+
+        assertFalse("viewModelScope should be cancelled after releaseResources", viewModel.isScopeActive)
     }
 
     @Test


### PR DESCRIPTION
## Summary

`MainViewModel.releaseResources()` closed channels and engines but did **not** cancel `viewModelScope`. In production this is fine — the Android framework's `super.onCleared()` cancels the scope **before** `releaseResources()` runs. In JVM tests, `releaseResources()` is called directly in `tearDown()` without the framework cancel firing first, so in-flight coroutines launched into `viewModelScope` could keep collecting `RecordingService.serviceEvents` and fire pipelines into the freshly-closed `crewMessages` channel — surfacing as noisy red-herring errors in test failure logs as more online-mode tests land in the Phase 1 cluster (#161, #162, #163).

## Mechanism

```kotlin
@VisibleForTesting
internal fun releaseResources() {
    viewModelScope.cancel()        // ← new: stop in-flight pipelines first
    crewMessages.close()
    sttEngine.close()
    ttsEngine.close()
    matrixClient?.let { client ->
        runBlocking(Dispatchers.IO + NonCancellable) { client.stop() }
    }
}
```

**Order matters.** Cancellation propagates to in-flight coroutines synchronously (`CancellationException` at next suspension point), so by the time `crewMessages.close()` runs, no live pipeline can observe a closed channel mid-emit.

**`runBlocking(NonCancellable)` is preserved.** The Matrix shutdown sequence is wrapped in `NonCancellable`, so the scope cancel above does not interrupt `matrixClient.stop()`.

**Production idempotency.** `super.onCleared()` cancels the scope first; `releaseResources()` then re-cancels (no-op on an already-cancelled scope). Test path now matches production semantics explicitly rather than implicitly relying on the framework.

## New test seam: `isScopeActive`

```kotlin
@VisibleForTesting
internal val isScopeActive: Boolean
    get() = viewModelScope.isActive
```

Single-line getter so tests can assert the scope's `Job` state directly without per-launch-site test seams (which the architect's T2 decision explicitly rejected — `ioDispatcher` is the only injectable dispatcher seam on `MainViewModel.Factory`).

## Test

```
MainViewModelTest.releaseResources cancels viewModelScope
```

Asserts `isScopeActive` flips `true → false` across the call. This is the safety net for #161 and #162, which depend on the cancel-then-close ordering being explicit.

## AC walk (#160 issue body)

- [x] **`releaseResources()` cancels `viewModelScope`** — added at the top, before any close call
- [x] **No more in-flight collectors firing pipelines into closed resources** — cancellation precedes channel close
- [x] **Tests still pass** — `./gradlew :app:test` green locally (warm-cache 26s); new test passes under `--rerun-tasks --tests "...releaseResources cancels viewModelScope"`

## Test plan

- [ ] CI: `Lint Workflows / actionlint` green (no workflow changes — sanity)
- [ ] CI: `Lint Workflows / scripts-test` green (no script changes — sanity)
- [ ] CI: `CI / build` green (Unit tests step exercises `MainViewModelTest` including the new cancel-assertion test)
- [ ] CI: `CI / license-audit` green (no dep changes — sanity)
- [ ] CI: `CI / instrumented-tests` green (no instrumented surface changes — sanity)

Closes #160

Generated with [Claude Code](https://claude.com/claude-code)
