### PR TITLE
fix(viewmodel): bound matrixClient.stop() with withTimeoutOrNull during teardown 🐛

### DIFF
--- a/app/src/main/java/dev/klazomenai/deckchat/MainViewModel.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/MainViewModel.kt
@@ -44,6 +44,15 @@ class MainViewModel(
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : ViewModel() {
 
+    init {
+        // `withTimeoutOrNull` throws IllegalArgumentException on non-positive
+        // timeMillis. Fail loud at VM construction (where bad config is
+        // diagnosable) rather than during teardown (the worst place to crash).
+        require(stopTimeoutMs > 0) {
+            "stopTimeoutMs must be > 0 (got $stopTimeoutMs); withTimeoutOrNull rejects non-positive timeouts"
+        }
+    }
+
     private val _state = MutableStateFlow<PipelineState>(PipelineState.Idle)
     val state: StateFlow<PipelineState> = _state.asStateFlow()
 

--- a/app/src/main/java/dev/klazomenai/deckchat/MainViewModel.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/MainViewModel.kt
@@ -40,6 +40,7 @@ class MainViewModel(
     private val audioFileProvider: () -> File,
     private val defaultCrew: String = DEFAULT_CREW,
     private val responseTimeoutMs: Long = DEFAULT_RESPONSE_TIMEOUT_MS,
+    private val stopTimeoutMs: Long = DEFAULT_STOP_TIMEOUT_MS,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : ViewModel() {
 
@@ -311,7 +312,20 @@ class MainViewModel(
         sttEngine.close()
         ttsEngine.close()
         matrixClient?.let { client ->
-            runBlocking(Dispatchers.IO + NonCancellable) { client.stop() }
+            // Bound the Matrix shutdown: a hung `stop()` (e.g. network stall during sync
+            // shutdown on a flaky link) inside `runBlocking` on the main thread is an ANR
+            // waiting to happen when the user backgrounds the app. `withTimeoutOrNull`
+            // returns null on timeout; we log + continue rather than throwing so the rest
+            // of cleanup completes deterministically. The cancel from withTimeoutOrNull
+            // does propagate into client.stop()'s suspension points (NonCancellable is on
+            // the outer parent — it can't be cancelled from above, but it does NOT
+            // intercept the timeout coroutine's cancel of its own child).
+            runBlocking(Dispatchers.IO + NonCancellable) {
+                val result = withTimeoutOrNull(stopTimeoutMs) { client.stop() }
+                if (result == null) {
+                    Log.w(TAG, "matrixClient.stop() timed out after ${stopTimeoutMs}ms; continuing cleanup")
+                }
+            }
         }
     }
 
@@ -332,12 +346,13 @@ class MainViewModel(
         private val audioFileProvider: () -> File,
         private val defaultCrew: String = DEFAULT_CREW,
         private val responseTimeoutMs: Long = DEFAULT_RESPONSE_TIMEOUT_MS,
+        private val stopTimeoutMs: Long = DEFAULT_STOP_TIMEOUT_MS,
         private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
     ) : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
             if (modelClass.isAssignableFrom(MainViewModel::class.java)) {
-                return MainViewModel(sttEngine, ttsEngine, matrixClient, roomId, audioFileProvider, defaultCrew, responseTimeoutMs, ioDispatcher) as T
+                return MainViewModel(sttEngine, ttsEngine, matrixClient, roomId, audioFileProvider, defaultCrew, responseTimeoutMs, stopTimeoutMs, ioDispatcher) as T
             }
             throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
         }
@@ -348,6 +363,10 @@ class MainViewModel(
         internal val DEFAULT_RESPONSE_TIMEOUT_MS = SecureStorage.DEFAULT_RESPONSE_TIMEOUT_SEC * 1000L
         internal const val DEFAULT_CREW = "maren"
         internal const val DELEGATION_SETTLE_MS = 5_000L
+        // Bounded teardown for matrixClient.stop() — five seconds is plenty of rope;
+        // anything longer means we're scuttling the boat while the user waits to
+        // background the app on a flaky link.
+        internal const val DEFAULT_STOP_TIMEOUT_MS = 5_000L
     }
 }
 

--- a/app/src/test/java/dev/klazomenai/deckchat/MainViewModelTest.kt
+++ b/app/src/test/java/dev/klazomenai/deckchat/MainViewModelTest.kt
@@ -150,6 +150,19 @@ class MainViewModelTest {
         assertFalse("viewModelScope should be cancelled after releaseResources", viewModel.isScopeActive)
     }
 
+    @Test(expected = IllegalArgumentException::class)
+    fun `MainViewModel rejects zero stopTimeoutMs at construction`() {
+        // withTimeoutOrNull throws IllegalArgumentException on non-positive
+        // timeMillis. Fail-loud at construction is preferable to crashing
+        // during teardown.
+        createViewModel(stopTimeoutMs = 0L)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `MainViewModel rejects negative stopTimeoutMs at construction`() {
+        createViewModel(stopTimeoutMs = -1L)
+    }
+
     @Test
     fun `releaseResources times out hung matrix stop`() {
         // Models the network-stall-during-sync-shutdown ANR vector closed by

--- a/app/src/test/java/dev/klazomenai/deckchat/MainViewModelTest.kt
+++ b/app/src/test/java/dev/klazomenai/deckchat/MainViewModelTest.kt
@@ -52,6 +52,7 @@ class MainViewModelTest {
         matrixClient: MatrixClient? = null,
         roomId: String? = null,
         defaultCrew: String = "maren",
+        stopTimeoutMs: Long = MainViewModel.DEFAULT_STOP_TIMEOUT_MS,
     ): MainViewModel {
         return MainViewModel(
             sttEngine = MockSttEngine(returnText = sttResult),
@@ -60,6 +61,7 @@ class MainViewModelTest {
             roomId = roomId,
             audioFileProvider = { audioFile },
             defaultCrew = defaultCrew,
+            stopTimeoutMs = stopTimeoutMs,
             ioDispatcher = testDispatcher,
         ).also { viewModels.add(it) }
     }
@@ -146,6 +148,38 @@ class MainViewModelTest {
         viewModel.releaseResources()
 
         assertFalse("viewModelScope should be cancelled after releaseResources", viewModel.isScopeActive)
+    }
+
+    @Test
+    fun `releaseResources times out hung matrix stop`() {
+        // Models the network-stall-during-sync-shutdown ANR vector closed by
+        // #162: MockMatrixClient.stop() suspends via awaitCancellation(), so
+        // without withTimeoutOrNull the runBlocking would block the calling
+        // thread until the JVM test runner kills the suite. With the timeout
+        // wrapper, releaseResources() returns within stopTimeoutMs and the
+        // stop body's stopCount++ line is never reached (cancelled mid-suspend).
+        //
+        // stopTimeoutMs = 100ms keeps the test cheap. The real-time elapsed
+        // here is the actual wait (runBlocking inside releaseResources uses
+        // a real Dispatchers.IO thread, not the testDispatcher — the timeout
+        // is real-time-based by design).
+        val client = MockMatrixClient(hangStop = true)
+        val viewModel = createViewModel(
+            matrixClient = client,
+            roomId = "!test:example.com",
+            stopTimeoutMs = 100L,
+        )
+
+        // If releaseResources doesn't honour stopTimeoutMs, this call hangs
+        // and the test runner kills the JVM after its own (much longer)
+        // timeout. The mere fact of returning is half the assertion.
+        viewModel.releaseResources()
+
+        assertEquals(
+            "stop() body should NOT have completed — withTimeoutOrNull should have cancelled the suspended call",
+            0,
+            client.stopCount,
+        )
     }
 
     @Test

--- a/app/src/test/java/dev/klazomenai/deckchat/MatrixClientTest.kt
+++ b/app/src/test/java/dev/klazomenai/deckchat/MatrixClientTest.kt
@@ -1,5 +1,6 @@
 package dev.klazomenai.deckchat
 
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -17,6 +18,12 @@ import org.junit.Test
 class MockMatrixClient(
     var shouldThrowOnSend: Boolean = false,
     var sendThrowMessage: String = "Matrix send failed",
+    /**
+     * When true, [stop] suspends indefinitely via [awaitCancellation]. Used by
+     * `MainViewModelTest.releaseResources times out hung matrix stop` to model
+     * the network-stall-during-sync-shutdown ANR vector that #162 closes.
+     */
+    var hangStop: Boolean = false,
 ) : MatrixClient {
     data class SentMessage(val roomId: String, val text: String)
 
@@ -56,6 +63,7 @@ class MockMatrixClient(
     }
 
     override suspend fun stop() {
+        if (hangStop) awaitCancellation()
         stopCount++
     }
 


### PR DESCRIPTION
## Summary

`MainViewModel.releaseResources()` calls `matrixClient.stop()` inside `runBlocking(Dispatchers.IO + NonCancellable)` with no upper bound. If `stop()` hangs — e.g. network stall during sync shutdown on a flaky link — the `runBlocking` blocks the calling thread until the OS kills the process. For `onCleared()` during activity destroy that's an ANR waiting to happen the next time the Captain backgrounds the app on a weak connection.

This PR wraps the stop in `withTimeoutOrNull(stopTimeoutMs)`, logs at warning on timeout, and continues the cleanup deterministically.

Surfaced independently by Copilot during PR #222's review (deferred there per the M2 plan's Phase 1 Cluster A stacking sequence; this PR closes the gap).

## Mechanism

```kotlin
@VisibleForTesting
internal fun releaseResources() {
    viewModelScope.cancel()
    crewMessages.close()
    sttEngine.close()
    ttsEngine.close()
    matrixClient?.let { client ->
        runBlocking(Dispatchers.IO + NonCancellable) {
            val result = withTimeoutOrNull(stopTimeoutMs) { client.stop() }
            if (result == null) {
                Log.w(TAG, "matrixClient.stop() timed out after ${stopTimeoutMs}ms; continuing cleanup")
            }
        }
    }
}
```

### Why this layering works

`runBlocking(Dispatchers.IO + NonCancellable)` prevents the **outer** caller (a cancelled coroutine in `onCleared`) from interrupting the cleanup. `withTimeoutOrNull` creates its own child Job (`TimeoutCoroutine`) with a real-time timer; when the timer fires, `TimeoutCoroutine.cancel()` propagates cancellation **downward** into `client.stop()`'s suspension points. `NonCancellable` is one level UP from `TimeoutCoroutine`, so it absorbs upward-flowing cancels (good — keeps cleanup running) without intercepting the timer's downward cancel of its own child.

### Why `withTimeoutOrNull` over `withTimeout`

`withTimeout` throws `TimeoutCancellationException`; `withTimeoutOrNull` returns `null`. The plan + issue body specify "log and continue" semantics, which is cleaner with the null-return variant: no try/catch, no exception object thrown across `runBlocking` boundaries.

## Configuration: `stopTimeoutMs`

Constructor parameter on `MainViewModel` (and threaded through `MainViewModel.Factory`), defaulting to `DEFAULT_STOP_TIMEOUT_MS = 5_000L`. Same shape as the existing `responseTimeoutMs` parameter — parallel pattern, parallel discoverability, no new dispatcher seam (the architect's T2 decision still holds: only `ioDispatcher` is a `Dispatcher`-typed seam).

**Default 5s rationale** (QM Notes): _"Five seconds is plenty of rope; anything longer means we're scuttling the boat."_ Real-world Matrix `stop()` on a healthy link completes in well under 1s; 5s allows for normal network-recovery jitter without blocking the user for an unreasonable backgrounding pause.

## Test surface

### New `MockMatrixClient.hangStop` knob

```kotlin
class MockMatrixClient(
    // ...
    var hangStop: Boolean = false,
) : MatrixClient {
    override suspend fun stop() {
        if (hangStop) awaitCancellation()
        stopCount++
    }
}
```

`awaitCancellation()` suspends forever until the surrounding job is cancelled — models the network-stall-during-sync-shutdown ANR vector directly. When the timeout fires, the suspended call is cancelled before `stopCount++` runs, so `stopCount == 0` post-cancel is the assertion handle.

### New test

```
MainViewModelTest.releaseResources times out hung matrix stop
```

Constructs a VM with `hangStop = true` and `stopTimeoutMs = 100L`. If `releaseResources()` doesn't honour the bound the call hangs, and the test runner eventually kills the JVM. Asserts `client.stopCount == 0` — proves the timeout fired and cancelled mid-suspend.

**Note on time discipline**: `runBlocking(Dispatchers.IO)` uses a real Dispatchers.IO thread, **not** the injected `testDispatcher`, so the `withTimeoutOrNull` timer is real-time-based by design (plan TF3 confirms this is the intended pattern). `stopTimeoutMs = 100L` in the test keeps wall-clock cost negligible.

## AC walk

### #162 (issue body)

- [x] **`withTimeoutOrNull` wrapped around `matrixClient.stop()`** — implemented at the source line in `releaseResources()`
- [x] **Default 5s** — matches issue's "e.g. 5s" guidance + QM Notes "five seconds is plenty of rope"
- [x] **Cleanup completes within bounded time** — verified by the new test (would hang → JVM-killed if regressed)

### Plan constraints

- [x] **Plan line 232** — `MainViewModelTest` covers `matrixClient.stop()` timeout (new test in place)
- [x] **Plan T2** — no new dispatcher seam; `stopTimeoutMs` is configuration, parallel to `responseTimeoutMs`
- [x] **Plan TF3 informational** — `withTimeoutOrNull` inside `runBlocking(IO)` is real-time-based, acknowledged in commit + test comments
- [x] **Plan stacking** — closes the Copilot-flagged ANR gap from PR #222 review per the locked Cluster A sequence

## Test plan

- [ ] CI: `Lint Workflows / actionlint` green (no workflow changes — sanity)
- [ ] CI: `Lint Workflows / scripts-test` green (no script changes — sanity)
- [ ] CI: `CI / build` green (Unit tests step exercises `MainViewModelTest` including the new timeout-assertion test)
- [ ] CI: `CI / license-audit` green (no dep changes — sanity)
- [ ] CI: `CI / instrumented-tests` green (no instrumented surface changes — sanity)

Closes #162

Generated with [Claude Code](https://claude.com/claude-code)
