### PR TITLE
fix(viewmodel): classify ClosedReceiveChannelException as PipelineCancelled 🐛

### DIFF
--- a/app/src/main/java/dev/klazomenai/deckchat/MainActivity.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/MainActivity.kt
@@ -397,6 +397,7 @@ class MainActivity : AppCompatActivity() {
         is PipelineError.TtsFailed -> getString(R.string.error_tts_failed, error.message)
         is PipelineError.MatrixFailed -> getString(R.string.error_matrix_failed, error.message)
         is PipelineError.ResponseTimeout -> getString(R.string.error_response_timeout)
+        is PipelineError.PipelineCancelled -> getString(R.string.error_pipeline_cancelled)
     }
 
     private fun showPermanentDenialDialog() {

--- a/app/src/main/java/dev/klazomenai/deckchat/MainViewModel.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/MainViewModel.kt
@@ -5,6 +5,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
@@ -241,14 +242,17 @@ class MainViewModel(
     // Stage strings are set and checked in this file only. Extract to a sealed type
     // when localising UI strings (M2) — see Copilot review on PR #89.
     private fun classifyError(e: Exception): PipelineError {
+        // Rethrow cooperative cancellation so the coroutine framework can honour it.
+        // When viewModelScope is cancelled (releaseResources → cancel-then-close ordering),
+        // CancellationException is what awaitFinalResponse() observes at its receive() call.
+        // Swallowing it here would produce a misleading SttFailed/MatrixFailed state
+        // and break structured-concurrency semantics.
+        if (e is CancellationException) throw e
         if (e is PipelineTimeoutException) return PipelineError.ResponseTimeout
         // ClosedReceiveChannelException fires when `crewMessages` is closed while
-        // `awaitFinalResponse()` is mid-`receive()`. Normally #160's cancel-then-close
-        // ordering means the receive observes CancellationException first, but this
-        // catch handles the defence-in-depth case: an unexpected direct close of
-        // `crewMessages` (e.g. a future caller bypassing `releaseResources()`)
-        // surfaces as a classified "pipeline cancelled" error rather than an
-        // unclassified crash-shaped UI message.
+        // `awaitFinalResponse()` is mid-`receive()` AND cancellation has not yet
+        // propagated. This is the defence-in-depth case for an unexpected direct
+        // close of `crewMessages` (e.g. a future caller bypassing `releaseResources()`).
         if (e is ClosedReceiveChannelException) return PipelineError.PipelineCancelled
         val state = _state.value
         return when {

--- a/app/src/main/java/dev/klazomenai/deckchat/MainViewModel.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/MainViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ClosedReceiveChannelException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -241,6 +242,14 @@ class MainViewModel(
     // when localising UI strings (M2) — see Copilot review on PR #89.
     private fun classifyError(e: Exception): PipelineError {
         if (e is PipelineTimeoutException) return PipelineError.ResponseTimeout
+        // ClosedReceiveChannelException fires when `crewMessages` is closed while
+        // `awaitFinalResponse()` is mid-`receive()`. Normally #160's cancel-then-close
+        // ordering means the receive observes CancellationException first, but this
+        // catch handles the defence-in-depth case: an unexpected direct close of
+        // `crewMessages` (e.g. a future caller bypassing `releaseResources()`)
+        // surfaces as a classified "pipeline cancelled" error rather than an
+        // unclassified crash-shaped UI message.
+        if (e is ClosedReceiveChannelException) return PipelineError.PipelineCancelled
         val state = _state.value
         return when {
             state is PipelineState.Processing && state.stage == "Transcribing" ->

--- a/app/src/main/java/dev/klazomenai/deckchat/PipelineState.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/PipelineState.kt
@@ -29,4 +29,14 @@ sealed class PipelineError {
     data class TtsFailed(val message: String) : PipelineError()
     data class MatrixFailed(val message: String) : PipelineError()
     data object ResponseTimeout : PipelineError()
+
+    /**
+     * Pipeline cancelled mid-flight — typically because the underlying crew
+     * message channel was closed (e.g. ViewModel teardown raced with
+     * `awaitFinalResponse()` mid-`receive()`). Distinguished from generic
+     * Matrix or STT failures so the UI can present a "we're shutting down,
+     * try again" message rather than misleading the user about which stage
+     * broke.
+     */
+    data object PipelineCancelled : PipelineError()
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,6 +47,7 @@
     <string name="error_tts_failed">Speech synthesis failed: %1$s</string>
     <string name="error_matrix_failed">Matrix connection failed: %1$s</string>
     <string name="error_response_timeout">Crew response timed out. Try increasing the timeout in Settings.</string>
+    <string name="error_pipeline_cancelled">Pipeline cancelled — try again.</string>
 
     <!-- Permission rationale dialog -->
     <string name="permission_rationale_title">Microphone access</string>

--- a/app/src/test/java/dev/klazomenai/deckchat/MainViewModelTest.kt
+++ b/app/src/test/java/dev/klazomenai/deckchat/MainViewModelTest.kt
@@ -512,6 +512,36 @@ class MainViewModelTest {
     }
 
     @Test
+    fun `closing crewMessages mid-await surfaces as PipelineCancelled`() = runTest {
+        // Models the race the Quartermaster's Notes describe: `releaseResources()`
+        // closes `crewMessages` while `awaitFinalResponse()` is mid-`receive()`.
+        // After #160's cancel-then-close ordering, the production race window is
+        // largely closed (the awaiting coroutine observes CancellationException
+        // first), but this test exercises the defence-in-depth path: an
+        // unexpected direct close of `crewMessages` (e.g. a future caller
+        // bypassing `releaseResources()`) must still classify cleanly as
+        // `PipelineCancelled` rather than as an unclassified Pipeline failed.
+        val (viewModel, _) = createOnlineViewModel()
+        testDispatcher.scheduler.advanceUntilIdle() // init + sync
+
+        // Drive pipeline up to `crewMessages.receive()` suspension point.
+        RecordingService.emitEvent(ServiceEvent.RecordingStopped)
+        testDispatcher.scheduler.runCurrent() // process event
+        testDispatcher.scheduler.runCurrent() // process pipeline launch + STT + send
+
+        // Close the channel directly — bypasses releaseResources() so
+        // viewModelScope is NOT cancelled and the receive observes the close
+        // as ClosedReceiveChannelException, not CancellationException.
+        viewModel.crewMessages.close()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(
+            PipelineState.Error(PipelineError.PipelineCancelled),
+            viewModel.state.value,
+        )
+    }
+
+    @Test
     fun `single crew message spoken after settling`() = runTest {
         val (viewModel, _) = createOnlineViewModel()
         testDispatcher.scheduler.advanceUntilIdle() // init + sync


### PR DESCRIPTION
## Summary

If `MainViewModel.releaseResources()` closes the `crewMessages` channel while `awaitFinalResponse()` is blocked on `receive()`, a `ClosedReceiveChannelException` propagates uncaught through the pipeline coroutine and surfaces as `PipelineError.SttFailed("Pipeline failed")` (the catch-all branch of `classifyError`). The user sees a misleading "STT failed" message for what is actually a teardown race.

After PR #222 landed `viewModelScope.cancel()` before `crewMessages.close()` in `releaseResources()`, the production race window is largely closed — the awaiting coroutine observes `CancellationException` first, before the channel close registers. This PR is **defence-in-depth**: any future caller that closes `crewMessages` directly (bypassing `releaseResources()`) would otherwise re-introduce the unclassified-error surface.

## Mechanism

### `PipelineState.kt` — new sealed-class variant

```kotlin
data object PipelineCancelled : PipelineError()
```

KDoc explicitly names the race scenario so future-us reading the source understands why this variant exists.

### `MainViewModel.classifyError` — add the check

```kotlin
private fun classifyError(e: Exception): PipelineError {
    if (e is PipelineTimeoutException) return PipelineError.ResponseTimeout
    if (e is ClosedReceiveChannelException) return PipelineError.PipelineCancelled
    // ...existing state-based fall-through unchanged...
}
```

Sits alongside the existing `PipelineTimeoutException` check — same shape (typed-exception → typed-error), same position in the function. The state-based fall-through below it is untouched.

### `MainActivity.errorText` — exhaustive `when` gains a branch

```kotlin
is PipelineError.PipelineCancelled -> getString(R.string.error_pipeline_cancelled)
```

The Kotlin compiler enforces exhaustiveness on the sealed class — adding the new variant without the branch is a build error. Caught at build time before this PR was even committed.

### `strings.xml` — new error message

```xml
<string name="error_pipeline_cancelled">Pipeline cancelled — try again.</string>
```

## Test

`MainViewModelTest.closing crewMessages mid-await surfaces as PipelineCancelled` (new):

- Drives the pipeline up to the `crewMessages.receive()` suspension point using the existing `createOnlineViewModel()` helper + `RecordingService.emitEvent(RecordingStopped)` pattern (matches the established `single crew message spoken after settling` test shape).
- Closes the channel **directly** (`viewModel.crewMessages.close()`) — bypasses `releaseResources()` so `viewModelScope` is NOT cancelled. The receive observes the close as `ClosedReceiveChannelException`, not `CancellationException`, which is exactly the path this PR's classifier handles.
- Asserts `state.value == PipelineState.Error(PipelineError.PipelineCancelled)`.

The test would still pass if #160's cancel-then-close ordering were ever reverted (the defence-in-depth catch fires regardless of teardown sequencing). That's by design — this PR's contract is "any closed-channel observation classifies cleanly", not "this specific teardown path classifies cleanly".

## AC walk

### #161 (issue body)

- [x] **Catch `ClosedReceiveChannelException`** — done in `classifyError`. Issue's "or" offered both `awaitFinalResponse()` or `runPipeline()` (= the outer `try { ... } catch (e: Exception)`); chose the latter via `classifyError` because the outer catch already routes every pipeline exception through it, so this scales to any future call site that hits the same suspension point.
- [x] **Classify as `PipelineError`** — new `PipelineCancelled` variant matches the issue's "pipeline cancelled / shutting down" wording.

### Plan constraints

- [x] **Plan line 232** — `MainViewModelTest` covers `awaitFinalResponse` empty-channel close (new integration test exactly this scenario).
- [x] **Plan stacking** — closes the next-after-#160 issue in Phase 1 Cluster A. #163 (response timeout for empty crew channel) is now unblocked (depends on #161 + #162, both done).

## Test plan

- [ ] CI: `Lint Workflows / actionlint` green (no workflow changes — sanity)
- [ ] CI: `Lint Workflows / scripts-test` green (no script changes — sanity)
- [ ] CI: `CI / build` green (Unit tests step exercises `MainViewModelTest` including the new classifier-assertion test; compileDebugKotlin enforces sealed-class exhaustiveness for `MainActivity.errorText`)
- [ ] CI: `CI / license-audit` green (no dep changes — sanity)
- [ ] CI: `CI / instrumented-tests` green (no instrumented surface changes — sanity)

Closes #161

Generated with [Claude Code](https://claude.com/claude-code)
