### PR TITLE
test(viewmodel): add response timeout test for empty crew channel 🧪

### DIFF
--- a/app/src/test/java/dev/klazomenai/deckchat/MainViewModelTest.kt
+++ b/app/src/test/java/dev/klazomenai/deckchat/MainViewModelTest.kt
@@ -498,14 +498,15 @@ class MainViewModelTest {
         sttResult: String = "hello",
         matrixClient: MockMatrixClient = MockMatrixClient(),
         roomId: String = "!room:example.com",
+        responseTimeoutMs: Long = MainViewModel.DEFAULT_RESPONSE_TIMEOUT_MS,
     ): Pair<MainViewModel, MockMatrixClient> {
-        val tts = MockTtsEngine()
         val vm = MainViewModel(
             sttEngine = MockSttEngine(returnText = sttResult),
-            ttsEngine = tts,
+            ttsEngine = MockTtsEngine(),
             matrixClient = matrixClient,
             roomId = roomId,
             audioFileProvider = { audioFile },
+            responseTimeoutMs = responseTimeoutMs,
             ioDispatcher = testDispatcher,
         ).also { viewModels.add(it) }
         return vm to matrixClient
@@ -537,6 +538,36 @@ class MainViewModelTest {
 
         assertEquals(
             PipelineState.Error(PipelineError.PipelineCancelled),
+            viewModel.state.value,
+        )
+    }
+
+    @Test
+    fun `no crew response times out with ResponseTimeout`() = runTest {
+        // Models the bridge-falls-silent path: pipeline reaches crewMessages.receive()
+        // but no crew message ever arrives. withTimeout(responseTimeoutMs) fires,
+        // TimeoutCancellationException is wrapped as PipelineTimeoutException, and
+        // classifyError maps it to PipelineError.ResponseTimeout.
+        //
+        // Uses a small responseTimeoutMs so the test advances past the deadline
+        // in virtual time without blocking real wall-clock time. The virtual-time
+        // mechanics mirror those of the delegation settling tests
+        // (withTimeoutOrNull(DELEGATION_SETTLE_MS) in awaitFinalResponse() is
+        // governed by the same testDispatcher scheduler).
+        val tinyTimeoutMs = 1_000L
+        val (viewModel, _) = createOnlineViewModel(responseTimeoutMs = tinyTimeoutMs)
+        testDispatcher.scheduler.advanceUntilIdle() // init + sync
+
+        RecordingService.emitEvent(ServiceEvent.RecordingStopped)
+        testDispatcher.scheduler.runCurrent() // process event
+        testDispatcher.scheduler.runCurrent() // process pipeline: STT + send, suspend at receive()
+
+        // No crew message sent — advance past the response deadline
+        testDispatcher.scheduler.advanceTimeBy(tinyTimeoutMs + 100)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(
+            PipelineState.Error(PipelineError.ResponseTimeout),
             viewModel.state.value,
         )
     }


### PR DESCRIPTION
## Summary

Adds the missing `PipelineError.ResponseTimeout` test to `MainViewModelTest`, closing the last uncovered branch in the response-timeout decision tree.

**The gap**: the online pipeline has three outcomes when waiting for a crew message: a message arrives (delegation settling tests), the channel closes unexpectedly (`closing crewMessages mid-await`, PR #224), and no message arrives before the deadline (this PR — untested until now). Without this test, future edits to the `withTimeout` wrapper or `classifyError` timeout branch could regress silently.

## Mechanism

The virtual-time mechanics mirror the delegation settling tests: `withTimeout(responseTimeoutMs)` in `runPipeline()` respects the `testDispatcher` scheduler exactly as `withTimeoutOrNull(DELEGATION_SETTLE_MS)` does in `awaitFinalResponse()`. A small `responseTimeoutMs = 1_000L` is used so `advanceTimeBy(tinyTimeoutMs + 100)` triggers the deadline without any real wall-clock wait.

### `createOnlineViewModel()` — new `responseTimeoutMs` parameter

Default = `MainViewModel.DEFAULT_RESPONSE_TIMEOUT_MS` so all existing callers are unaffected.

### New test: `no crew response times out with ResponseTimeout`

```
advanceUntilIdle()          // init + sync
emitEvent(RecordingStopped)
runCurrent()                // process event
runCurrent()                // STT + send, suspend at receive()
advanceTimeBy(1_100)        // past deadline
advanceUntilIdle()          // error classification + state update
assertEquals Error(ResponseTimeout)
```

## AC walk

### #163 (issue body)

- [x] **Advance time past `responseTimeoutMs`** — `advanceTimeBy(tinyTimeoutMs + 100)` fires `withTimeout`.
- [x] **Assert `PipelineState.Error(PipelineError.ResponseTimeout)`** — exact assertion.
- [x] **No crew messages sent** — channel left open, no `trySend` calls.
- [x] **Placement in delegation settling section** — test lives immediately before `single crew message spoken after settling`.

### Plan constraints

- [x] **Depends on #161 + #162** — both merged. `PipelineError.ResponseTimeout` classification in `classifyError` is stable.
- [x] **Phase 1 Cluster A** — #163 is the final issue in the cluster (#178 → #159 → #160 → #162 → #161 → #163).

## Test plan

- [ ] CI: `CI / build` green (`testDebugUnitTest` passes — all 35 tests including the new one; `compileDebugKotlin` confirms no type errors)
- [ ] CI: `CI / license-audit` green (no dep changes — sanity)
- [ ] CI: `CI / instrumented-tests` green (no instrumented surface changes — sanity)

Closes #163
