### PR TITLE
fix(matrix): allow hyphens in crew prefix regex verbosity group 🐛

### DIFF
--- a/app/src/main/java/dev/klazomenai/deckchat/MatrixClient.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/MatrixClient.kt
@@ -75,4 +75,4 @@ fun parseCrewMessage(body: String, sender: String): CrewMessage? {
     )
 }
 
-private val CREW_PREFIX_REGEX = Regex("""\[(\w+):(\w+)]\s*(.+)""", RegexOption.DOT_MATCHES_ALL)
+private val CREW_PREFIX_REGEX = Regex("""\[([\w-]+):([\w-]+)]\s*(.+)""", RegexOption.DOT_MATCHES_ALL)

--- a/app/src/test/java/dev/klazomenai/deckchat/MatrixClientTest.kt
+++ b/app/src/test/java/dev/klazomenai/deckchat/MatrixClientTest.kt
@@ -137,6 +137,22 @@ class MatrixClientTest {
         assertEquals("Line one\nLine two\nLine three", result?.body)
     }
 
+    @Test
+    fun `parseCrewMessage handles hyphenated verbosity`() {
+        val result = parseCrewMessage("[chips:log-entry] Done.", "@bot:example.com")
+        assertEquals("chips", result?.crewName)
+        assertEquals("log-entry", result?.verbosity)
+        assertEquals("Done.", result?.body)
+    }
+
+    @Test
+    fun `parseCrewMessage handles bosun log-entry verbosity`() {
+        val result = parseCrewMessage("[bosun:log-entry] Logged.", "@bot:example.com")
+        assertEquals("bosun", result?.crewName)
+        assertEquals("log-entry", result?.verbosity)
+        assertEquals("Logged.", result?.body)
+    }
+
     // --- Mock client tests ---
 
     @Test


### PR DESCRIPTION
`parseCrewMessage` used `\w+` for the verbosity capture group, which excludes hyphens. Crews with hyphenated verbosity values (`log-entry` — Chips and Bosun) had every response silently dropped; DeckChat would time out waiting. Maren and Crest (verbosity `dispatch`) were unaffected.

## Changes

- `MatrixClient.kt`: widen regex from `\[(\w+):(\w+)]` to `\[([\w-]+):([\w-]+)]`
- `MatrixClientTest.kt`: two new unit tests covering `[chips:log-entry]` and `[bosun:log-entry]`

## Test plan

- [x] Unit tests green (14/14)
- [x] Install debug APK, send "Chips list issues" from DeckChat, verify crew response received and spoken

Refs #241
