### PR TITLE
refactor(onboarding): hoist login state into OnboardingViewModel ♻️

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -161,14 +161,24 @@ android {
         }
     }
 
-    // testOptions block intentionally absent — `unitTests.isReturnDefaultValues`
-    // defaults to false, which is what we want: every JVM test that touches the
-    // Android framework must use @RunWith(RobolectricTestRunner::class) so real
-    // framework stubs are wired in. The `returnDefaultValues = true` escape hatch
-    // silently stubs every un-mocked Android call (e.g. Context.getResources()
-    // returning null), masking bugs. Robolectric + @Config(sdk = [34]) is the
-    // discipline; see app/src/test/java/.../MainViewModelTest.kt and the other
-    // four Robolectric-annotated tests.
+    // `unitTests.isReturnDefaultValues` is intentionally NOT set (defaults to false):
+    // every JVM test that touches the Android framework must use
+    // @RunWith(RobolectricTestRunner::class) so real framework stubs are wired in.
+    // The `returnDefaultValues = true` escape hatch silently stubs every un-mocked
+    // Android call (e.g. Context.getResources() returning null), masking bugs.
+    //
+    // `isIncludeAndroidResources = true` is required for Robolectric binary resource
+    // tests. Without it, AGP does not set the `android_resource_apk` system property,
+    // so Robolectric's DefaultManifestFactory never loads the compiled resources.arsc,
+    // the 0x7f package is absent from CppAssetManager2, and any call that routes
+    // through obtainStyledAttributes() — including AppCompat's theme check in
+    // createSubDecor() — receives an empty TypedArray and throws
+    // "You need to use a Theme.AppCompat theme". OnboardingActivityTest requires this.
+    testOptions {
+        unitTests {
+            isIncludeAndroidResources = true
+        }
+    }
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -43,7 +43,8 @@
 
         <activity android:name=".SettingsActivity" />
 
-        <activity android:name=".OnboardingActivity" />
+        <activity android:name=".OnboardingActivity"
+            android:theme="@style/Theme.DeckChat" />
 
         <!-- Headset button → start/stop RecordingService.
              exported=true required: system delivers ACTION_MEDIA_BUTTON from outside the app.

--- a/app/src/main/java/dev/klazomenai/deckchat/DeckChatApplication.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/DeckChatApplication.kt
@@ -18,10 +18,13 @@ import kotlinx.coroutines.runBlocking
 open class DeckChatApplication : Application() {
 
     /**
-     * App-wide singleton SecureStorage. Lazy so the Tink keyset load + Keystore round-trip
-     * happens once and is shared across all callers. Call-site refactor (rewriting the five
-     * dispersed construction sites to use this property) lands in the sibling PR for #226 —
-     * this PR adds the property only.
+     * App-wide [SecureStorage] singleton. Lazily initialised so the Tink keyset load and
+     * Keystore round-trip happens once and is shared across all callers (MainActivity,
+     * SettingsActivity, OnboardingActivity, and their ViewModels).
+     *
+     * Declared `open` so test [Application] subclasses can override with a
+     * [SecureStorage.PlaintextTokenEncryptor]-backed instance that avoids the Android
+     * Keystore dependency in JVM unit tests.
      */
     open val secureStorage: SecureStorage by lazy { SecureStorage(applicationContext) }
 

--- a/app/src/main/java/dev/klazomenai/deckchat/DeckChatApplication.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/DeckChatApplication.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.runBlocking
  * crashes visible in logcat. File-based persistence and richer crash reporting
  * are future enhancements.
  */
-class DeckChatApplication : Application() {
+open class DeckChatApplication : Application() {
 
     /**
      * App-wide singleton SecureStorage. Lazy so the Tink keyset load + Keystore round-trip
@@ -23,7 +23,7 @@ class DeckChatApplication : Application() {
      * dispersed construction sites to use this property) lands in the sibling PR for #226 —
      * this PR adds the property only.
      */
-    val secureStorage: SecureStorage by lazy { SecureStorage(applicationContext) }
+    open val secureStorage: SecureStorage by lazy { SecureStorage(applicationContext) }
 
     override fun onCreate() {
         super.onCreate()

--- a/app/src/main/java/dev/klazomenai/deckchat/OnboardingActivity.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/OnboardingActivity.kt
@@ -16,8 +16,10 @@ import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import kotlinx.coroutines.launch
 
 open class OnboardingActivity : AppCompatActivity() {
@@ -128,28 +130,33 @@ open class OnboardingActivity : AppCompatActivity() {
         val loginError = findViewById<TextView>(R.id.login_error)
 
         lifecycleScope.launch {
-            viewModel.loginState.collect { state ->
-                when (state) {
-                    is OnboardingViewModel.LoginState.Idle -> {
-                        loginProgress.visibility = View.GONE
-                        loginError.visibility = View.GONE
-                        btnNext.isEnabled = true
-                    }
-                    is OnboardingViewModel.LoginState.InProgress -> {
-                        loginProgress.visibility = View.VISIBLE
-                        loginError.visibility = View.GONE
-                        btnNext.isEnabled = false
-                    }
-                    is OnboardingViewModel.LoginState.Error -> {
-                        loginProgress.visibility = View.GONE
-                        loginError.text = state.message
-                        loginError.visibility = View.VISIBLE
-                        btnNext.isEnabled = true
-                    }
-                    is OnboardingViewModel.LoginState.Success -> {
-                        loginProgress.visibility = View.GONE
-                        loginError.visibility = View.GONE
-                        if (currentStep == STEP_LOGIN) advanceStep()
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.loginState.collect { state ->
+                    when (state) {
+                        is OnboardingViewModel.LoginState.Idle -> {
+                            loginProgress.visibility = View.GONE
+                            loginError.visibility = View.GONE
+                            btnNext.isEnabled = true
+                        }
+                        is OnboardingViewModel.LoginState.InProgress -> {
+                            loginProgress.visibility = View.VISIBLE
+                            loginError.visibility = View.GONE
+                            btnNext.isEnabled = false
+                        }
+                        is OnboardingViewModel.LoginState.Error -> {
+                            loginProgress.visibility = View.GONE
+                            loginError.text = state.message
+                            loginError.visibility = View.VISIBLE
+                            btnNext.isEnabled = true
+                        }
+                        is OnboardingViewModel.LoginState.Success -> {
+                            loginProgress.visibility = View.GONE
+                            loginError.visibility = View.GONE
+                            if (currentStep == STEP_LOGIN) {
+                                advanceStep()
+                                viewModel.acknowledgeSuccess()
+                            }
+                        }
                     }
                 }
             }

--- a/app/src/main/java/dev/klazomenai/deckchat/OnboardingActivity.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/OnboardingActivity.kt
@@ -148,6 +148,7 @@ open class OnboardingActivity : AppCompatActivity() {
                     }
                     is OnboardingViewModel.LoginState.Success -> {
                         loginProgress.visibility = View.GONE
+                        loginError.visibility = View.GONE
                         if (currentStep == STEP_LOGIN) advanceStep()
                     }
                 }

--- a/app/src/main/java/dev/klazomenai/deckchat/OnboardingActivity.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/OnboardingActivity.kt
@@ -62,9 +62,9 @@ open class OnboardingActivity : AppCompatActivity() {
             currentStep = savedInstanceState.getInt(KEY_CURRENT_STEP, 0)
         }
 
-        setupLoginStateObserver()
         setupPermissionsStep()
         showStep(currentStep)
+        setupLoginStateObserver()
 
         btnBack.setOnClickListener { goBack() }
         btnNext.setOnClickListener { goNext() }

--- a/app/src/main/java/dev/klazomenai/deckchat/OnboardingActivity.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/OnboardingActivity.kt
@@ -6,7 +6,6 @@ import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
-import android.util.Log
 import android.view.View
 import android.widget.Button
 import android.widget.EditText
@@ -17,16 +16,14 @@ import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
-import kotlin.coroutines.cancellation.CancellationException
-import kotlinx.coroutines.CoroutineExceptionHandler
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
-class OnboardingActivity : AppCompatActivity() {
+open class OnboardingActivity : AppCompatActivity() {
 
     private val storage get() = (application as DeckChatApplication).secureStorage
+    private lateinit var viewModel: OnboardingViewModel
     private var currentStep = 0
 
     private lateinit var stepViews: List<View>
@@ -58,10 +55,14 @@ class OnboardingActivity : AppCompatActivity() {
             findViewById(R.id.step_bluetooth),
         )
 
+        viewModel = ViewModelProvider(this, OnboardingViewModel.Factory(application))
+            .get(OnboardingViewModel::class.java)
+
         if (savedInstanceState != null) {
             currentStep = savedInstanceState.getInt(KEY_CURRENT_STEP, 0)
         }
 
+        setupLoginStateObserver()
         setupPermissionsStep()
         showStep(currentStep)
 
@@ -122,13 +123,43 @@ class OnboardingActivity : AppCompatActivity() {
 
     // --- Step 1: Login ---
 
+    private fun setupLoginStateObserver() {
+        val loginProgress = findViewById<ProgressBar>(R.id.login_progress)
+        val loginError = findViewById<TextView>(R.id.login_error)
+
+        lifecycleScope.launch {
+            viewModel.loginState.collect { state ->
+                when (state) {
+                    is OnboardingViewModel.LoginState.Idle -> {
+                        loginProgress.visibility = View.GONE
+                        loginError.visibility = View.GONE
+                        btnNext.isEnabled = true
+                    }
+                    is OnboardingViewModel.LoginState.InProgress -> {
+                        loginProgress.visibility = View.VISIBLE
+                        loginError.visibility = View.GONE
+                        btnNext.isEnabled = false
+                    }
+                    is OnboardingViewModel.LoginState.Error -> {
+                        loginProgress.visibility = View.GONE
+                        loginError.text = state.message
+                        loginError.visibility = View.VISIBLE
+                        btnNext.isEnabled = true
+                    }
+                    is OnboardingViewModel.LoginState.Success -> {
+                        loginProgress.visibility = View.GONE
+                        if (currentStep == STEP_LOGIN) advanceStep()
+                    }
+                }
+            }
+        }
+    }
+
     private fun validateAndLogin() {
         val homeserverInput = findViewById<EditText>(R.id.onboarding_homeserver_url)
         val usernameInput = findViewById<EditText>(R.id.onboarding_username)
         val passwordInput = findViewById<EditText>(R.id.onboarding_password)
         val roomIdInput = findViewById<EditText>(R.id.onboarding_room_id)
-        val loginProgress = findViewById<ProgressBar>(R.id.login_progress)
-        val loginError = findViewById<TextView>(R.id.login_error)
 
         val url = homeserverInput.text.toString().trim()
         val username = usernameInput.text.toString().trim()
@@ -142,43 +173,7 @@ class OnboardingActivity : AppCompatActivity() {
         if (password.isEmpty()) { passwordInput.error = "Required"; return }
         if (roomId.isEmpty()) { roomIdInput.error = "Required"; return }
 
-        loginProgress.visibility = View.VISIBLE
-        loginError.visibility = View.GONE
-        btnNext.isEnabled = false
-
-        val coroutineErrorHandler = CoroutineExceptionHandler { _, throwable ->
-            Log.e(TAG, "Unhandled coroutine exception during login", throwable)
-            runOnUiThread {
-                loginProgress.visibility = View.GONE
-                loginError.text = throwable.message ?: "Login failed unexpectedly"
-                loginError.visibility = View.VISIBLE
-                btnNext.isEnabled = true
-            }
-        }
-
-        lifecycleScope.launch(coroutineErrorHandler) {
-            try {
-                withContext(Dispatchers.IO) {
-                    val host = Uri.parse(url).host ?: "unknown"
-                    Log.d(TAG, "Creating RustMatrixClient for $host")
-                    val client = RustMatrixClient(applicationContext, storage)
-                    Log.d(TAG, "RustMatrixClient created, starting login")
-                    client.login(url, username, password)
-                    Log.d(TAG, "Login successful")
-                }
-                storage.roomId = roomId
-                loginProgress.visibility = View.GONE
-                advanceStep()
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                Log.e(TAG, "Login failed: ${e.javaClass.name}", e)
-                loginProgress.visibility = View.GONE
-                loginError.text = e.message ?: "Login failed (${e.javaClass.name})"
-                loginError.visibility = View.VISIBLE
-                btnNext.isEnabled = true
-            }
-        }
+        viewModel.validateAndLogin(url, username, password, roomId)
     }
 
     // --- Step 2: Voice ---

--- a/app/src/main/java/dev/klazomenai/deckchat/OnboardingViewModel.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/OnboardingViewModel.kt
@@ -35,6 +35,7 @@ class OnboardingViewModel(
     val loginState: StateFlow<LoginState> = _loginState.asStateFlow()
 
     fun validateAndLogin(url: String, username: String, password: String, roomId: String) {
+        if (_loginState.value is LoginState.InProgress) return
         viewModelScope.launch {
             _loginState.value = LoginState.InProgress
             try {
@@ -57,6 +58,9 @@ class OnboardingViewModel(
     class Factory(private val application: Application) : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            require(modelClass.isAssignableFrom(OnboardingViewModel::class.java)) {
+                "Unknown ViewModel class: ${modelClass.name}"
+            }
             val storage = (application as DeckChatApplication).secureStorage
             return OnboardingViewModel(application, storage) as T
         }

--- a/app/src/main/java/dev/klazomenai/deckchat/OnboardingViewModel.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/OnboardingViewModel.kt
@@ -55,6 +55,12 @@ class OnboardingViewModel(
         }
     }
 
+    fun acknowledgeSuccess() {
+        if (_loginState.value is LoginState.Success) {
+            _loginState.value = LoginState.Idle
+        }
+    }
+
     class Factory(private val application: Application) : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>): T {

--- a/app/src/main/java/dev/klazomenai/deckchat/OnboardingViewModel.kt
+++ b/app/src/main/java/dev/klazomenai/deckchat/OnboardingViewModel.kt
@@ -1,0 +1,68 @@
+package dev.klazomenai.deckchat
+
+import android.app.Application
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class OnboardingViewModel(
+    private val application: Application,
+    private val storage: SecureStorage,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val loginAction: suspend (url: String, username: String, password: String) -> Unit = { url, username, password ->
+        val client = RustMatrixClient(application, storage)
+        client.login(url, username, password)
+    },
+) : ViewModel() {
+
+    sealed class LoginState {
+        object Idle : LoginState()
+        object InProgress : LoginState()
+        data class Error(val message: String) : LoginState()
+        object Success : LoginState()
+    }
+
+    private val _loginState = MutableStateFlow<LoginState>(LoginState.Idle)
+    val loginState: StateFlow<LoginState> = _loginState.asStateFlow()
+
+    fun validateAndLogin(url: String, username: String, password: String, roomId: String) {
+        viewModelScope.launch {
+            _loginState.value = LoginState.InProgress
+            try {
+                withContext(ioDispatcher) {
+                    Log.d(TAG, "Starting login for ${android.net.Uri.parse(url).host ?: "unknown"}")
+                    loginAction(url, username, password)
+                    Log.d(TAG, "Login successful")
+                }
+                storage.roomId = roomId
+                _loginState.value = LoginState.Success
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Log.e(TAG, "Login failed: ${e.javaClass.name}", e)
+                _loginState.value = LoginState.Error(e.message ?: "Login failed (${e.javaClass.simpleName})")
+            }
+        }
+    }
+
+    class Factory(private val application: Application) : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            val storage = (application as DeckChatApplication).secureStorage
+            return OnboardingViewModel(application, storage) as T
+        }
+    }
+
+    companion object {
+        private const val TAG = "DeckChat.Onboarding"
+    }
+}

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="Theme.DeckChat" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
         <item name="colorPrimary">@color/navy</item>
         <item name="colorPrimaryVariant">@color/navy_dark</item>
         <item name="colorOnPrimary">@color/white</item>

--- a/app/src/test/java/dev/klazomenai/deckchat/OnboardingActivityTest.kt
+++ b/app/src/test/java/dev/klazomenai/deckchat/OnboardingActivityTest.kt
@@ -1,0 +1,135 @@
+package dev.klazomenai.deckchat
+
+import android.content.Context
+import android.content.pm.ActivityInfo
+import android.view.View
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.Implementation
+import org.robolectric.annotation.Implements
+
+/**
+ * Robolectric baseline for [OnboardingActivity] — step navigation and state restoration.
+ *
+ * Uses [TestDeckChatApplication] to inject a plain-SharedPreferences [SecureStorage],
+ * avoiding the Android Keystore dependency that [TinkAeadPrefs] requires at construction time.
+ *
+ * Robolectric compatibility workarounds for AppCompat 1.7.x + MaterialComponents:
+ *
+ * 1. [ShadowResourceManagerInternal]: suppresses AppCompat's vector-drawable setup probe
+ *    (checkVectorDrawableSetup), which fails on abc_vector_test from a ContextThemeWrapper
+ *    in Robolectric's binary-resource loader.
+ *
+ * 2. [registerActivityTheme]: Robolectric 4.16.1 + SDK 34 has a bug where
+ *    PackageParser.generatePackageInfo returns an empty activities array, so
+ *    packageInfos never receives ActivityInfo.theme from the binary manifest.
+ *    ShadowActivity.callAttach() then calls addActivityIfNotPresent() which inserts
+ *    a blank ActivityInfo (theme=0), meaning setTheme() is never called, and
+ *    AppCompatDelegateImpl.createSubDecor() throws "You need to use a Theme.AppCompat theme".
+ *    Fix: call shadowOf(pm).addOrUpdateActivity() in @Before to register the activity
+ *    with theme=R.style.Theme_DeckChat before any buildActivity() call.
+ *
+ * Covers #211 baseline ACs and the rotation/error state ACs from #203.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(
+    sdk = [34],
+    application = OnboardingActivityTest.TestDeckChatApplication::class,
+    shadows = [OnboardingActivityTest.ShadowResourceManagerInternal::class],
+)
+class OnboardingActivityTest {
+
+    class TestDeckChatApplication : DeckChatApplication() {
+        override val secureStorage: SecureStorage by lazy {
+            SecureStorage(
+                getSharedPreferences("test_onboarding", Context.MODE_PRIVATE),
+                SecureStorage.PlaintextTokenEncryptor(),
+            )
+        }
+    }
+
+    @Implements(className = "androidx.appcompat.widget.ResourceManagerInternal", looseSignatures = true)
+    class ShadowResourceManagerInternal {
+        @Implementation
+        fun checkVectorDrawableSetup(context: Any?) {
+            // no-op — suppress AppCompat 1.7.x vector-drawable probe in unit tests
+        }
+    }
+
+    /**
+     * Robolectric 4.16.1 + SDK 34 bug: PackageParser.generatePackageInfo returns an empty
+     * activities array, so the binary manifest theme is never stored in packageInfos.
+     * Register the activity with its declared theme before each test so ShadowActivity
+     * finds a non-zero themeResource and calls setTheme() during attach.
+     */
+    @Before
+    fun registerActivityTheme() {
+        val app = RuntimeEnvironment.getApplication()
+        val activityInfo = ActivityInfo().apply {
+            packageName = app.packageName
+            name = OnboardingActivity::class.java.name
+            theme = R.style.Theme_DeckChat
+        }
+        val shadowPm = shadowOf(app.packageManager)
+        shadowPm.addOrUpdateActivity(activityInfo)
+
+        // Verify registration took effect before any buildActivity() call
+        val rawPkg = shadowPm.getInternalMutablePackageInfo(app.packageName)
+        val stored = rawPkg?.activities?.firstOrNull { it.name == OnboardingActivity::class.java.name }
+        assertEquals(
+            "@Before: activity not found in packageInfos after addOrUpdateActivity",
+            OnboardingActivity::class.java.name, stored?.name,
+        )
+        assertEquals(
+            "@Before: theme not set after addOrUpdateActivity (stored.theme)",
+            R.style.Theme_DeckChat, stored?.theme ?: 0,
+        )
+    }
+
+    // --- #211 baseline ---
+
+    @Test
+    fun `cold start lands on STEP_LOGIN`() {
+        val activity = Robolectric.buildActivity(OnboardingActivity::class.java)
+            .create().start().resume().get()
+        val stepLogin = activity.findViewById<View>(R.id.step_login)
+        assertEquals(View.VISIBLE, stepLogin.visibility)
+    }
+
+    @Test
+    fun `cold start STEP_LOGIN visible within 500ms`() {
+        val start = System.nanoTime()
+        val activity = Robolectric.buildActivity(OnboardingActivity::class.java)
+            .create().start().resume().get()
+        val stepLogin = activity.findViewById<View>(R.id.step_login)
+        val elapsedMs = (System.nanoTime() - start) / 1_000_000
+        assertEquals(View.VISIBLE, stepLogin.visibility)
+        assertTrue("onCreate exceeded 500ms budget (${elapsedMs}ms)", elapsedMs < 500)
+    }
+
+    @Test
+    fun `rotation on STEP_LOGIN preserves currentStep`() {
+        val controller = Robolectric.buildActivity(OnboardingActivity::class.java)
+            .create().start().resume()
+        controller.recreate()
+        val activity = controller.get()
+        val stepLogin = activity.findViewById<View>(R.id.step_login)
+        assertEquals(View.VISIBLE, stepLogin.visibility)
+    }
+
+    @Test
+    fun `back press on first step finishes activity`() {
+        val activity = Robolectric.buildActivity(OnboardingActivity::class.java)
+            .create().start().resume().get()
+        activity.onBackPressedDispatcher.onBackPressed()
+        assertTrue(activity.isFinishing)
+    }
+}

--- a/app/src/test/java/dev/klazomenai/deckchat/OnboardingActivityTest.kt
+++ b/app/src/test/java/dev/klazomenai/deckchat/OnboardingActivityTest.kt
@@ -101,6 +101,13 @@ class OnboardingActivityTest {
         Dispatchers.setMain(testDispatcher)
 
         val app = RuntimeEnvironment.getApplication()
+
+        // Clear the stable "test_onboarding" SharedPreferences so any prior test's writes
+        // (e.g. roomId set on a successful login) cannot leak into subsequent tests and
+        // create order-dependent failures.
+        app.getSharedPreferences("test_onboarding", Context.MODE_PRIVATE)
+            .edit().clear().commit()
+
         val activityInfo = ActivityInfo().apply {
             packageName = app.packageName
             name = OnboardingActivity::class.java.name
@@ -143,7 +150,10 @@ class OnboardingActivityTest {
         val testVm = OnboardingViewModel(
             activity.application,
             (activity.application as DeckChatApplication).secureStorage,
-            ioDispatcher = Dispatchers.Unconfined,
+            // Use the same UnconfinedTestDispatcher that backs Dispatchers.Main so the
+            // viewModelScope launch + withContext(io) switch is driven by test-controlled
+            // scheduling, not the global Dispatchers.Unconfined.
+            ioDispatcher = testDispatcher,
             loginAction = loginAction,
         )
         val factory = object : ViewModelProvider.Factory {
@@ -172,7 +182,7 @@ class OnboardingActivityTest {
         val stepLogin = activity.findViewById<View>(R.id.step_login)
         val elapsedMs = (System.nanoTime() - start) / 1_000_000
         assertEquals(View.VISIBLE, stepLogin.visibility)
-        assertTrue("onCreate exceeded 500ms budget (${elapsedMs}ms)", elapsedMs < 500)
+        assertTrue("onCreate exceeded 500ms budget (${elapsedMs}ms)", elapsedMs <= 500)
     }
 
     @Test

--- a/app/src/test/java/dev/klazomenai/deckchat/OnboardingActivityTest.kt
+++ b/app/src/test/java/dev/klazomenai/deckchat/OnboardingActivityTest.kt
@@ -41,7 +41,7 @@ import org.robolectric.annotation.Implements
  *    (checkVectorDrawableSetup), which fails on abc_vector_test from a ContextThemeWrapper
  *    in Robolectric's binary-resource loader.
  *
- * 2. [registerActivityTheme]: Robolectric 4.16.1 + SDK 34 has a bug where
+ * 2. [setUp] (`@Before`): Robolectric 4.16.1 + SDK 34 has a bug where
  *    PackageParser.generatePackageInfo returns an empty activities array, so
  *    packageInfos never receives ActivityInfo.theme from the binary manifest.
  *    ShadowActivity.callAttach() then calls addActivityIfNotPresent() which inserts

--- a/app/src/test/java/dev/klazomenai/deckchat/OnboardingActivityTest.kt
+++ b/app/src/test/java/dev/klazomenai/deckchat/OnboardingActivityTest.kt
@@ -37,7 +37,9 @@ import org.robolectric.annotation.Implements
  *    Fix: call shadowOf(pm).addOrUpdateActivity() in @Before to register the activity
  *    with theme=R.style.Theme_DeckChat before any buildActivity() call.
  *
- * Covers #211 baseline ACs and the rotation/error state ACs from #203.
+ * Covers #211 baseline ACs (cold start, activity-creation budget, idle-state step
+ * restoration, first-step back-press). In-flight / error-state rotation coverage and
+ * multi-step back-press coverage are deferred to #211 and #226 respectively.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(

--- a/app/src/test/java/dev/klazomenai/deckchat/OnboardingActivityTest.kt
+++ b/app/src/test/java/dev/klazomenai/deckchat/OnboardingActivityTest.kt
@@ -2,8 +2,21 @@ package dev.klazomenai.deckchat
 
 import android.content.Context
 import android.content.pm.ActivityInfo
+import android.os.Bundle
 import android.view.View
+import android.widget.TextView
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -37,10 +50,12 @@ import org.robolectric.annotation.Implements
  *    Fix: call shadowOf(pm).addOrUpdateActivity() in @Before to register the activity
  *    with theme=R.style.Theme_DeckChat before any buildActivity() call.
  *
- * Covers #211 baseline ACs (cold start, activity-creation budget, idle-state step
- * restoration, first-step back-press). In-flight / error-state rotation coverage and
- * multi-step back-press coverage are deferred to #211 and #226 respectively.
+ * Covers #211 baseline ACs (cold start, activity-creation budget, step rotation across all
+ * four onboarding steps, first-step back-press) and #203 ACs (rotation preserves InProgress
+ * without re-firing login; rotation preserves Error UI). Multi-step back-press coverage is
+ * deferred to #226.
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
 @Config(
     sdk = [34],
@@ -48,6 +63,15 @@ import org.robolectric.annotation.Implements
     shadows = [OnboardingActivityTest.ShadowResourceManagerInternal::class],
 )
 class OnboardingActivityTest {
+
+    /**
+     * Bundle key duplicated from [OnboardingActivity.KEY_CURRENT_STEP] (private). If the
+     * production constant is renamed, the multi-step rotation tests will fail noisily
+     * with a wrong-step assertion, which is the correct failure mode for a contract break.
+     */
+    private val keyCurrentStep = "current_step"
+
+    private val testDispatcher = UnconfinedTestDispatcher()
 
     class TestDeckChatApplication : DeckChatApplication() {
         override val secureStorage: SecureStorage by lazy {
@@ -73,7 +97,9 @@ class OnboardingActivityTest {
      * finds a non-zero themeResource and calls setTheme() during attach.
      */
     @Before
-    fun registerActivityTheme() {
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+
         val app = RuntimeEnvironment.getApplication()
         val activityInfo = ActivityInfo().apply {
             packageName = app.packageName
@@ -94,6 +120,38 @@ class OnboardingActivityTest {
             "@Before: theme not set after addOrUpdateActivity (stored.theme)",
             R.style.Theme_DeckChat, stored?.theme ?: 0,
         )
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    /**
+     * Pre-populates the activity's [ViewModelStore][androidx.lifecycle.ViewModelStore] with
+     * a test [OnboardingViewModel] whose `loginAction` is controllable. The activity's
+     * subsequent `ViewModelProvider(this, OnboardingViewModel.Factory(application))` call
+     * finds the pre-loaded VM by key and returns it, so [OnboardingViewModel.Factory.create]
+     * (which would build a real [RustMatrixClient]) never runs.
+     *
+     * Must be called between `Robolectric.buildActivity()` and `controller.create()`.
+     */
+    private fun preloadTestViewModel(
+        activity: OnboardingActivity,
+        loginAction: suspend (String, String, String) -> Unit,
+    ): OnboardingViewModel {
+        val testVm = OnboardingViewModel(
+            activity.application,
+            (activity.application as DeckChatApplication).secureStorage,
+            ioDispatcher = Dispatchers.Unconfined,
+            loginAction = loginAction,
+        )
+        val factory = object : ViewModelProvider.Factory {
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : ViewModel> create(modelClass: Class<T>): T = testVm as T
+        }
+        ViewModelProvider(activity, factory).get(OnboardingViewModel::class.java)
+        return testVm
     }
 
     // --- #211 baseline ---
@@ -128,11 +186,115 @@ class OnboardingActivityTest {
     }
 
     @Test
+    fun `rotation on STEP_VOICE preserves currentStep`() {
+        val state = Bundle().apply { putInt(keyCurrentStep, 1) }
+        val controller = Robolectric.buildActivity(OnboardingActivity::class.java)
+            .create(state).start().resume()
+        controller.recreate()
+        val activity = controller.get()
+        val stepVoice = activity.findViewById<View>(R.id.step_voice)
+        val stepLogin = activity.findViewById<View>(R.id.step_login)
+        assertEquals(View.VISIBLE, stepVoice.visibility)
+        assertEquals(View.GONE, stepLogin.visibility)
+    }
+
+    @Test
+    fun `rotation on STEP_PERMISSIONS preserves currentStep`() {
+        val state = Bundle().apply { putInt(keyCurrentStep, 2) }
+        val controller = Robolectric.buildActivity(OnboardingActivity::class.java)
+            .create(state).start().resume()
+        controller.recreate()
+        val activity = controller.get()
+        val stepPermissions = activity.findViewById<View>(R.id.step_permissions)
+        val stepVoice = activity.findViewById<View>(R.id.step_voice)
+        assertEquals(View.VISIBLE, stepPermissions.visibility)
+        assertEquals(View.GONE, stepVoice.visibility)
+    }
+
+    @Test
+    fun `rotation on STEP_BLUETOOTH preserves currentStep`() {
+        val state = Bundle().apply { putInt(keyCurrentStep, 3) }
+        val controller = Robolectric.buildActivity(OnboardingActivity::class.java)
+            .create(state).start().resume()
+        controller.recreate()
+        val activity = controller.get()
+        val stepBluetooth = activity.findViewById<View>(R.id.step_bluetooth)
+        val stepPermissions = activity.findViewById<View>(R.id.step_permissions)
+        assertEquals(View.VISIBLE, stepBluetooth.visibility)
+        assertEquals(View.GONE, stepPermissions.visibility)
+    }
+
+    @Test
     fun `back press on first step finishes activity`() {
         val activity = Robolectric.buildActivity(OnboardingActivity::class.java)
             .create().start().resume().get()
         activity.onBackPressedDispatcher.onBackPressed()
         assertTrue(activity.isFinishing)
+    }
+
+    // --- #203 in-flight + error rotation ---
+
+    @Test
+    fun `rotation during InProgress preserves InProgress UI without re-firing login`() {
+        val loginProceed = CompletableDeferred<Unit>()
+        val loginCallCount = AtomicInteger(0)
+
+        val controller = Robolectric.buildActivity(OnboardingActivity::class.java)
+        val testVm = preloadTestViewModel(controller.get()) { _, _, _ ->
+            loginCallCount.incrementAndGet()
+            loginProceed.await()
+        }
+        controller.create().start().resume()
+
+        testVm.validateAndLogin("https://matrix.example.com", "user", "pass", "!room:example.com")
+        assertEquals(OnboardingViewModel.LoginState.InProgress, testVm.loginState.value)
+
+        controller.recreate()
+        val recreated = controller.get()
+
+        // VM survives recreate via NonConfigurationInstances; state is still InProgress.
+        assertEquals(OnboardingViewModel.LoginState.InProgress, testVm.loginState.value)
+
+        // The recreated Activity's new collector picks up the retained InProgress and
+        // renders the spinner; the error view stays hidden.
+        val progress = recreated.findViewById<View>(R.id.login_progress)
+        val error = recreated.findViewById<View>(R.id.login_error)
+        assertEquals(View.VISIBLE, progress.visibility)
+        assertEquals(View.GONE, error.visibility)
+
+        // Login was fired exactly once across the whole rotation.
+        assertEquals(1, loginCallCount.get())
+
+        loginProceed.complete(Unit)
+    }
+
+    @Test
+    fun `rotation during Error preserves Error UI`() {
+        val controller = Robolectric.buildActivity(OnboardingActivity::class.java)
+        val testVm = preloadTestViewModel(controller.get()) { _, _, _ ->
+            throw RuntimeException("bad credentials")
+        }
+        controller.create().start().resume()
+
+        testVm.validateAndLogin("https://matrix.example.com", "user", "wrong", "!room:example.com")
+        val before = testVm.loginState.value
+        assertTrue("Expected Error before rotation, got $before", before is OnboardingViewModel.LoginState.Error)
+
+        controller.recreate()
+        val recreated = controller.get()
+
+        // VM + state survive recreate.
+        val after = testVm.loginState.value
+        assertTrue(after is OnboardingViewModel.LoginState.Error)
+        assertEquals("bad credentials", (after as OnboardingViewModel.LoginState.Error).message)
+
+        // The recreated Activity's collector replays Error and renders the error text.
+        val errorView = recreated.findViewById<TextView>(R.id.login_error)
+        val progress = recreated.findViewById<View>(R.id.login_progress)
+        assertEquals(View.VISIBLE, errorView.visibility)
+        assertEquals("bad credentials", errorView.text.toString())
+        assertEquals(View.GONE, progress.visibility)
+        assertFalse(recreated.isFinishing)
     }
 
     // --- OnboardingViewModel.Factory ---

--- a/app/src/test/java/dev/klazomenai/deckchat/OnboardingActivityTest.kt
+++ b/app/src/test/java/dev/klazomenai/deckchat/OnboardingActivityTest.kt
@@ -134,4 +134,26 @@ class OnboardingActivityTest {
         activity.onBackPressedDispatcher.onBackPressed()
         assertTrue(activity.isFinishing)
     }
+
+    // --- OnboardingViewModel.Factory ---
+
+    @Test
+    fun `Factory creates ViewModel using TestDeckChatApplication secureStorage`() {
+        // TestDeckChatApplication overrides secureStorage with PlaintextTokenEncryptor,
+        // so Factory.create() must succeed without Android Keystore.
+        val vm = OnboardingViewModel.Factory(RuntimeEnvironment.getApplication())
+            .create(OnboardingViewModel::class.java)
+        assertEquals(OnboardingViewModel.LoginState.Idle, vm.loginState.value)
+    }
+
+    @Test
+    fun `Factory throws for unrelated ViewModel class`() {
+        val factory = OnboardingViewModel.Factory(RuntimeEnvironment.getApplication())
+        try {
+            factory.create(MainViewModel::class.java)
+            throw AssertionError("Expected IllegalArgumentException")
+        } catch (e: IllegalArgumentException) {
+            assertTrue(e.message!!.contains("Unknown ViewModel class"))
+        }
+    }
 }

--- a/app/src/test/java/dev/klazomenai/deckchat/OnboardingViewModelTest.kt
+++ b/app/src/test/java/dev/klazomenai/deckchat/OnboardingViewModelTest.kt
@@ -2,6 +2,7 @@ package dev.klazomenai.deckchat
 
 import android.app.Application
 import android.content.Context
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
@@ -75,7 +76,10 @@ class OnboardingViewModelTest {
         advanceUntilIdle()
         job.cancel()
 
-        assertTrue("InProgress must be emitted before Success", states.contains(OnboardingViewModel.LoginState.InProgress))
+        val inProgressIdx = states.indexOf(OnboardingViewModel.LoginState.InProgress)
+        val successIdx = states.lastIndexOf(OnboardingViewModel.LoginState.Success)
+        assertTrue("InProgress must appear before Success in state sequence",
+            inProgressIdx in 0 until successIdx)
         assertEquals(OnboardingViewModel.LoginState.Success, states.last())
         assertEquals("!room:example.com", storage.roomId)
     }
@@ -101,5 +105,28 @@ class OnboardingViewModelTest {
         val seenByNewCollector = vm.loginState.first()
 
         assertTrue(seenByNewCollector is OnboardingViewModel.LoginState.Error)
+    }
+
+    @Test
+    fun `second validateAndLogin call while InProgress is dropped`() = runTest {
+        val loginProceed = CompletableDeferred<Unit>()
+        val vm = OnboardingViewModel(
+            application,
+            storage,
+            ioDispatcher = StandardTestDispatcher(testScheduler),
+            loginAction = { _, _, _ -> loginProceed.await() },
+        )
+
+        vm.validateAndLogin("https://matrix.example.com", "user", "pass", "!room:example.com")
+        advanceUntilIdle()  // drives coroutine into loginProceed.await(); state = InProgress
+
+        vm.validateAndLogin("https://matrix.example.com", "user2", "pass2", "!room2:example.com")
+        assertEquals(OnboardingViewModel.LoginState.InProgress, vm.loginState.value)
+
+        loginProceed.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(OnboardingViewModel.LoginState.Success, vm.loginState.value)
+        assertEquals("!room:example.com", storage.roomId)  // first call's roomId, not second
     }
 }

--- a/app/src/test/java/dev/klazomenai/deckchat/OnboardingViewModelTest.kt
+++ b/app/src/test/java/dev/klazomenai/deckchat/OnboardingViewModelTest.kt
@@ -1,0 +1,88 @@
+package dev.klazomenai.deckchat
+
+import android.app.Application
+import android.content.Context
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class OnboardingViewModelTest {
+
+    private lateinit var storage: SecureStorage
+    private lateinit var application: Application
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @Before
+    fun setUp() {
+        application = RuntimeEnvironment.getApplication()
+        val prefs = application.getSharedPreferences("test_onboarding", Context.MODE_PRIVATE)
+        prefs.edit().clear().commit()
+        storage = SecureStorage(prefs, SecureStorage.PlaintextTokenEncryptor())
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun viewModel(
+        loginAction: suspend (String, String, String) -> Unit = { _, _, _ -> },
+    ) = OnboardingViewModel(application, storage, ioDispatcher = testDispatcher, loginAction = loginAction)
+
+    @Test
+    fun `initial loginState is Idle`() = runTest {
+        val vm = viewModel()
+        assertEquals(OnboardingViewModel.LoginState.Idle, vm.loginState.value)
+    }
+
+    @Test
+    fun `validateAndLogin transitions to InProgress then Success`() = runTest {
+        val vm = viewModel(loginAction = { _, _, _ -> /* no-op — instant success */ })
+
+        vm.validateAndLogin("https://matrix.example.com", "user", "pass", "!room:example.com")
+
+        assertEquals(OnboardingViewModel.LoginState.Success, vm.loginState.value)
+        assertEquals("!room:example.com", storage.roomId)
+    }
+
+    @Test
+    fun `validateAndLogin transitions to Error on login failure`() = runTest {
+        val vm = viewModel(loginAction = { _, _, _ -> throw RuntimeException("bad credentials") })
+
+        vm.validateAndLogin("https://matrix.example.com", "user", "wrong", "!room:example.com")
+
+        val state = vm.loginState.value
+        assertTrue(state is OnboardingViewModel.LoginState.Error)
+        assertEquals("bad credentials", (state as OnboardingViewModel.LoginState.Error).message)
+    }
+
+    @Test
+    fun `loginState re-emits last value to new collector (rotation semantics)`() = runTest {
+        val vm = viewModel(loginAction = { _, _, _ -> throw RuntimeException("oops") })
+
+        vm.validateAndLogin("https://matrix.example.com", "user", "pass", "!room:example.com")
+
+        // New collector (simulates Activity recreation after rotation) sees the last state.
+        val collected = mutableListOf<OnboardingViewModel.LoginState>()
+        val state = vm.loginState.value
+        collected.add(state)
+
+        assertTrue(collected.first() is OnboardingViewModel.LoginState.Error)
+    }
+}

--- a/app/src/test/java/dev/klazomenai/deckchat/OnboardingViewModelTest.kt
+++ b/app/src/test/java/dev/klazomenai/deckchat/OnboardingViewModelTest.kt
@@ -4,7 +4,11 @@ import android.app.Application
 import android.content.Context
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -53,11 +57,26 @@ class OnboardingViewModelTest {
 
     @Test
     fun `validateAndLogin transitions to InProgress then Success`() = runTest {
-        val vm = viewModel(loginAction = { _, _, _ -> /* no-op — instant success */ })
+        // Use StandardTestDispatcher for io so withContext() suspends for real, giving the
+        // StateFlow collector a chance to process InProgress before Success is emitted.
+        // With UnconfinedTestDispatcher on both sides, withContext is a no-op and StateFlow
+        // conflation hides InProgress before the collector wakes up.
+        val vm = OnboardingViewModel(
+            application,
+            storage,
+            ioDispatcher = StandardTestDispatcher(testScheduler),
+            loginAction = { _, _, _ -> /* no-op — instant success */ },
+        )
+
+        val states = mutableListOf<OnboardingViewModel.LoginState>()
+        val job = launch { vm.loginState.collect { states.add(it) } }
 
         vm.validateAndLogin("https://matrix.example.com", "user", "pass", "!room:example.com")
+        advanceUntilIdle()
+        job.cancel()
 
-        assertEquals(OnboardingViewModel.LoginState.Success, vm.loginState.value)
+        assertTrue("InProgress must be emitted before Success", states.contains(OnboardingViewModel.LoginState.InProgress))
+        assertEquals(OnboardingViewModel.LoginState.Success, states.last())
         assertEquals("!room:example.com", storage.roomId)
     }
 
@@ -75,14 +94,12 @@ class OnboardingViewModelTest {
     @Test
     fun `loginState re-emits last value to new collector (rotation semantics)`() = runTest {
         val vm = viewModel(loginAction = { _, _, _ -> throw RuntimeException("oops") })
-
         vm.validateAndLogin("https://matrix.example.com", "user", "pass", "!room:example.com")
 
-        // New collector (simulates Activity recreation after rotation) sees the last state.
-        val collected = mutableListOf<OnboardingViewModel.LoginState>()
-        val state = vm.loginState.value
-        collected.add(state)
+        // A new collector (created after Activity recreation on rotation) must immediately
+        // receive the retained Error state — StateFlow guarantees replay of last value.
+        val seenByNewCollector = vm.loginState.first()
 
-        assertTrue(collected.first() is OnboardingViewModel.LoginState.Error)
+        assertTrue(seenByNewCollector is OnboardingViewModel.LoginState.Error)
     }
 }

--- a/app/src/test/java/dev/klazomenai/deckchat/OnboardingViewModelTest.kt
+++ b/app/src/test/java/dev/klazomenai/deckchat/OnboardingViewModelTest.kt
@@ -77,9 +77,12 @@ class OnboardingViewModelTest {
         job.cancel()
 
         val inProgressIdx = states.indexOf(OnboardingViewModel.LoginState.InProgress)
-        val successIdx = states.lastIndexOf(OnboardingViewModel.LoginState.Success)
-        assertTrue("InProgress must appear before Success in state sequence",
-            inProgressIdx in 0 until successIdx)
+        val firstSuccessIdx = states.indexOf(OnboardingViewModel.LoginState.Success)
+        // Both indices must be valid AND InProgress must precede the FIRST Success.
+        // Using indexOf (first occurrence) ensures a broken Success→InProgress→Success
+        // sequence would give firstSuccessIdx < inProgressIdx and fail the assertion.
+        assertTrue("InProgress must appear before first Success in state sequence",
+            inProgressIdx in 0 until firstSuccessIdx)
         assertEquals(OnboardingViewModel.LoginState.Success, states.last())
         assertEquals("!room:example.com", storage.roomId)
     }


### PR DESCRIPTION
## Summary

- Hoists login async logic from `OnboardingActivity` into `OnboardingViewModel` with a `LoginState` sealed class (`Idle` / `InProgress` / `Error` / `Success`), decoupling coroutine lifecycle from the Activity and making state rotation-safe
- Opens `DeckChatApplication.secureStorage` for test injection; unit tests bypass the Tink/Keystore constructor via `PlaintextTokenEncryptor`
- Adds `testOptions.isIncludeAndroidResources = true` to Gradle so Robolectric binary resources load correctly

## Test plan

- [x] `OnboardingViewModelTest` — 5 unit tests: Idle initial state, InProgress→Success happy path, Error on failure, rotation semantics (StateFlow replay to new collector), double-submit guard while InProgress
- [x] `OnboardingActivityTest` — 11 Robolectric tests:
  - **#211 baseline (7)** — cold start lands on STEP_LOGIN; 500ms cold-start budget; rotation preserves currentStep on each of STEP_LOGIN / STEP_VOICE / STEP_PERMISSIONS / STEP_BLUETOOTH; first-step back-press finishes activity
  - **#203 in-flight + error rotation (2)** — rotation during InProgress preserves the spinner UI and `loginAction` is not re-fired across the recreate; rotation during Error preserves the error text on the recreated Activity (VM survives via `NonConfigurationInstances`)
  - **`OnboardingViewModel.Factory` (2)** — Factory uses `TestDeckChatApplication.secureStorage`; Factory rejects unrelated ViewModel classes
- [x] All 16 unit test suites pass locally (181 tests, 0 failures, 0 errors)

## ACs closed by this PR

### Issue #203 (6 ACs)

| # | AC | Status |
|---|---|---|
| 1 | `OnboardingViewModel` exists with `loginState: StateFlow<LoginState>` | ✅ full |
| 2 | `STEP_LOGIN` collects from the flow via `setupLoginStateObserver()` | ✅ full |
| 3 | Rotation during `InProgress` preserves state — no leak, no re-fire (Activity-level test verifies UI + `loginCallCount == 1`) | ✅ full |
| 4 | `Error` state survives rotation (Activity-level test verifies UI text + retained state) | ✅ full |
| 5 | Robolectric test (#211 baseline) covers rotation across each onboarding step (4 per-step rotation tests) | ✅ full |
| `AC-#203.5` | Factory reads from `(application as DeckChatApplication).secureStorage`, not direct construction | ✅ full |

### Issue #211 (5 ACs)

| # | AC | Status |
|---|---|---|
| 1 | `OnboardingActivityTest` exists and runs | ✅ full |
| 2 | All 4 baseline cases pass (cold-start, advance through each step, rotation across each step, back-press reverses one step) | ⚠️ **partial** — see breakdown below |
| 3 | Class is structured for extension (per-concern tests, `preloadTestViewModel()` helper, `@Before`/`@After` plumbing) | ✅ full |
| 4 | Documented in #209's `docs/testing.md` | ❌ owned by #209 |
| `AC-#211.5` | Cold-start completes within 500ms budget (`elapsedMs <= 500`) | ⚠️ **partial** — caveat below |

#### AC-#211.2 baseline breakdown

| Scope-defined baseline case | Coverage |
|---|---|
| Cold-start lands on STEP_LOGIN | ✅ `cold start lands on STEP_LOGIN` |
| Advance through each step | ⚠️ **untested as click-through.** The rotation tests reach each step via `Bundle.putInt("current_step", N)` (savedInstanceState injection), so each step's view is verified visible, but the `goNext()` → `showStep()` advance logic itself is not exercised by clicking `btnNext`. Follow-up to be filed unless folded into #226. |
| Rotation across each step preserves currentStep | ✅ 4 per-step rotation tests |
| Back-press reverses one step | ⚠️ only the first-step finish path is covered (`currentStep == 0` → activity finishes). Multi-step reversal (`currentStep > 0` → decrement, Activity stays alive) is deferred to #226 (operator decision, [discussion-r3259811281](https://github.com/Klazomenai/deck-chat/pull/243#discussion_r3259811281)). |

#### AC-#211.5 caveat

The 500ms timer starts inside `Robolectric.buildActivity(...)`, after `RuntimeEnvironment.getApplication()` has already initialised the Application. So the measurement window covers **Activity creation + layout inflation only** — `Application.onCreate()` (which is what AC-#211.5's stated rationale targets, since `MigrationGate.migrateIfNeeded()` runs there) is **not** in the budget. The AC's literal text ("Activity.onCreate → STEP_LOGIN visible") matches the test, but the rationale's intent (defending B4 from MigrationGate runtime in Application.onCreate) is not defended by this test. A full-process-boot measurement is a future follow-up.

Refs #203
Refs #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)
